### PR TITLE
Add department and initiative filters to statistics API

### DIFF
--- a/src/Application/Interfaces/Services/IGeneralStatisticsService.cs
+++ b/src/Application/Interfaces/Services/IGeneralStatisticsService.cs
@@ -16,4 +16,20 @@ public interface IGeneralStatisticsService
     /// <param name="ct">Cancellation token.</param>
     /// <returns>General statistics data.</returns>
     Task<CustomWebResponse> GetGeneralStatisticsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Get general statistics filtered by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>General statistics data for the department.</returns>
+    Task<CustomWebResponse> GetGeneralStatisticsByDepartmentAsync(int departmentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get general statistics filtered by initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>General statistics data for the initiative.</returns>
+    Task<CustomWebResponse> GetGeneralStatisticsByInitiativeAsync(int initiativeId, CancellationToken ct = default);
 }

--- a/src/Application/Services/Statistics/GeneralStatisticsService.cs
+++ b/src/Application/Services/Statistics/GeneralStatisticsService.cs
@@ -30,50 +30,8 @@ public class GeneralStatisticsService : IGeneralStatisticsService
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>General statistics data.</returns>
-    public async Task<CustomWebResponse> GetGeneralStatisticsAsync(CancellationToken ct = default)
-    {
-        // Calculate statistics using private methods
-        var totalActiveInitiatives = await GetTotalActiveInitiativesCountAsync(ct);
-        var totalPeopleInvolved = await GetTotalPeopleInvolvedCountAsync(ct);
-        var totalAreaInHectares = await GetTotalAreaInHectaresAsync(ct);
-
-        // Validate data integrity
-        if (totalActiveInitiatives < 0)
-        {
-            return new CustomWebResponse(true)
-            {
-                Message = "Invalid data: negative initiative count",
-            };
-        }
-
-        if (totalPeopleInvolved < 0)
-        {
-            return new CustomWebResponse(true)
-            {
-                Message = "Invalid data: negative people count",
-            };
-        }
-
-        if (totalAreaInHectares < 0)
-        {
-            return new CustomWebResponse(true)
-            {
-                Message = "Invalid data: negative area value",
-            };
-        }
-
-        var statistics = new GeneralStatisticsDto
-        {
-            TotalActiveInitiatives = totalActiveInitiatives,
-            TotalPeopleInvolved = totalPeopleInvolved,
-            TotalAreaInHectares = totalAreaInHectares,
-        };
-
-        return new CustomWebResponse
-        {
-            ResponseBody = statistics,
-        };
-    }
+    public async Task<CustomWebResponse> GetGeneralStatisticsAsync(CancellationToken ct = default) =>
+        await GetGeneralStatisticsInternalAsync(null, null, ct);
 
     /// <summary>
     /// Get general statistics filtered by department.
@@ -81,50 +39,8 @@ public class GeneralStatisticsService : IGeneralStatisticsService
     /// <param name="departmentId">Department identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>General statistics data for the department.</returns>
-    public async Task<CustomWebResponse> GetGeneralStatisticsByDepartmentAsync(int departmentId, CancellationToken ct = default)
-    {
-        // Calculate statistics using private methods
-        var totalActiveInitiatives = await GetTotalActiveInitiativesCountByDepartmentAsync(departmentId, ct);
-        var totalPeopleInvolved = await GetTotalPeopleInvolvedCountByDepartmentAsync(departmentId, ct);
-        var totalAreaInHectares = await GetTotalAreaInHectaresByDepartmentAsync(departmentId, ct);
-
-        // Validate data integrity
-        if (totalActiveInitiatives < 0)
-        {
-            return new CustomWebResponse(true)
-            {
-                Message = "Invalid data: negative initiative count",
-            };
-        }
-
-        if (totalPeopleInvolved < 0)
-        {
-            return new CustomWebResponse(true)
-            {
-                Message = "Invalid data: negative people count",
-            };
-        }
-
-        if (totalAreaInHectares < 0)
-        {
-            return new CustomWebResponse(true)
-            {
-                Message = "Invalid data: negative area value",
-            };
-        }
-
-        var statistics = new GeneralStatisticsDto
-        {
-            TotalActiveInitiatives = totalActiveInitiatives,
-            TotalPeopleInvolved = totalPeopleInvolved,
-            TotalAreaInHectares = totalAreaInHectares,
-        };
-
-        return new CustomWebResponse
-        {
-            ResponseBody = statistics,
-        };
-    }
+    public async Task<CustomWebResponse> GetGeneralStatisticsByDepartmentAsync(int departmentId, CancellationToken ct = default) =>
+        await GetGeneralStatisticsInternalAsync(departmentId, null, ct);
 
     /// <summary>
     /// Get general statistics filtered by initiative.
@@ -132,12 +48,44 @@ public class GeneralStatisticsService : IGeneralStatisticsService
     /// <param name="initiativeId">Initiative identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>General statistics data for the initiative.</returns>
-    public async Task<CustomWebResponse> GetGeneralStatisticsByInitiativeAsync(int initiativeId, CancellationToken ct = default)
+    public async Task<CustomWebResponse> GetGeneralStatisticsByInitiativeAsync(int initiativeId, CancellationToken ct = default) =>
+        await GetGeneralStatisticsInternalAsync(null, initiativeId, ct);
+
+    /// <summary>
+    /// Internal method to get general statistics with optional filters.
+    /// </summary>
+    /// <param name="departmentId">Department identifier (optional).</param>
+    /// <param name="initiativeId">Initiative identifier (optional).</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>General statistics data.</returns>
+    private async Task<CustomWebResponse> GetGeneralStatisticsInternalAsync(int? departmentId, int? initiativeId, CancellationToken ct = default)
     {
-        // Calculate statistics using private methods
-        var totalActiveInitiatives = await GetTotalActiveInitiativesCountByInitiativeAsync(initiativeId, ct);
-        var totalPeopleInvolved = await GetTotalPeopleInvolvedCountByInitiativeAsync(initiativeId, ct);
-        var totalAreaInHectares = await GetTotalAreaInHectaresByInitiativeAsync(initiativeId, ct);
+        // Calculate statistics based on filters
+        int totalActiveInitiatives;
+        int totalPeopleInvolved;
+        double totalAreaInHectares;
+
+        if (departmentId.HasValue)
+        {
+            totalActiveInitiatives = await initiativeRepository.GetActiveInitiativesCountByDepartmentAsync(departmentId.Value, ct);
+            totalPeopleInvolved = await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountByDepartmentAsync(departmentId.Value, ct);
+            var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesByDepartmentAsync(departmentId.Value, ct);
+            totalAreaInHectares = Math.Round(totalAreaInSquareKm * 100, 2); // Convert from km² to hectares
+        }
+        else if (initiativeId.HasValue)
+        {
+            totalActiveInitiatives = await initiativeRepository.GetActiveInitiativesCountByInitiativeAsync(initiativeId.Value, ct);
+            totalPeopleInvolved = await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountByInitiativeAsync(initiativeId.Value, ct);
+            var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesByInitiativeAsync(initiativeId.Value, ct);
+            totalAreaInHectares = Math.Round(totalAreaInSquareKm * 100, 2); // Convert from km² to hectares
+        }
+        else
+        {
+            totalActiveInitiatives = await initiativeRepository.GetActiveInitiativesCountAsync(ct);
+            totalPeopleInvolved = await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountAsync(ct);
+            var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesAsync(ct);
+            totalAreaInHectares = Math.Round(totalAreaInSquareKm * 100, 2); // Convert from km² to hectares
+        }
 
         // Validate data integrity
         if (totalActiveInitiatives < 0)
@@ -175,98 +123,5 @@ public class GeneralStatisticsService : IGeneralStatisticsService
         {
             ResponseBody = statistics,
         };
-    }
-
-    /// <summary>
-    /// Get total count of active initiatives by department.
-    /// </summary>
-    /// <param name="departmentId">Department identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Count of active initiatives in the department.</returns>
-    private async Task<int> GetTotalActiveInitiativesCountByDepartmentAsync(int departmentId, CancellationToken ct = default) =>
-        await initiativeRepository.GetActiveInitiativesCountByDepartmentAsync(departmentId, ct);
-
-    /// <summary>
-    /// Get total count of people involved in active initiatives by department.
-    /// </summary>
-    /// <param name="departmentId">Department identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Count of people involved in the department.</returns>
-    private async Task<int> GetTotalPeopleInvolvedCountByDepartmentAsync(int departmentId, CancellationToken ct = default) =>
-        await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountByDepartmentAsync(departmentId, ct);
-
-    /// <summary>
-    /// Get total area of active initiatives by department in hectares.
-    /// </summary>
-    /// <param name="departmentId">Department identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Total area in hectares for the department.</returns>
-    private async Task<double> GetTotalAreaInHectaresByDepartmentAsync(int departmentId, CancellationToken ct = default)
-    {
-        var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesByDepartmentAsync(departmentId, ct);
-
-        // Convert from km² to hectares (1 km² = 100 hectares)
-        return Math.Round(totalAreaInSquareKm * 100, 2);
-    }
-
-    /// <summary>
-    /// Get total count of active initiatives by specific initiative.
-    /// </summary>
-    /// <param name="initiativeId">Initiative identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Count of active initiatives (should be 1 or 0).</returns>
-    private async Task<int> GetTotalActiveInitiativesCountByInitiativeAsync(int initiativeId, CancellationToken ct = default) =>
-        await initiativeRepository.GetActiveInitiativesCountByInitiativeAsync(initiativeId, ct);
-
-    /// <summary>
-    /// Get total count of people involved in active initiatives by specific initiative.
-    /// </summary>
-    /// <param name="initiativeId">Initiative identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Count of people involved in the initiative.</returns>
-    private async Task<int> GetTotalPeopleInvolvedCountByInitiativeAsync(int initiativeId, CancellationToken ct = default) =>
-        await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountByInitiativeAsync(initiativeId, ct);
-
-    /// <summary>
-    /// Get total area of active initiatives by specific initiative in hectares.
-    /// </summary>
-    /// <param name="initiativeId">Initiative identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Total area in hectares for the initiative.</returns>
-    private async Task<double> GetTotalAreaInHectaresByInitiativeAsync(int initiativeId, CancellationToken ct = default)
-    {
-        var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesByInitiativeAsync(initiativeId, ct);
-
-        // Convert from km² to hectares (1 km² = 100 hectares)
-        return Math.Round(totalAreaInSquareKm * 100, 2);
-    }
-
-    /// <summary>
-    /// Get total count of active initiatives.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Count of active initiatives.</returns>
-    private async Task<int> GetTotalActiveInitiativesCountAsync(CancellationToken ct = default) =>
-        await initiativeRepository.GetActiveInitiativesCountAsync(ct);
-
-    /// <summary>
-    /// Get total count of people involved in active initiatives.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Count of people involved.</returns>
-    private async Task<int> GetTotalPeopleInvolvedCountAsync(CancellationToken ct = default) =>
-        await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountAsync(ct);
-
-    /// <summary>
-    /// Get total area of active initiatives in hectares.
-    /// </summary>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Total area in hectares.</returns>
-    private async Task<double> GetTotalAreaInHectaresAsync(CancellationToken ct = default)
-    {
-        var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesAsync(ct);
-
-        // Convert from km² to hectares (1 km² = 100 hectares)
-        return Math.Round(totalAreaInSquareKm * 100, 2);
     }
 }

--- a/src/Application/Services/Statistics/GeneralStatisticsService.cs
+++ b/src/Application/Services/Statistics/GeneralStatisticsService.cs
@@ -76,6 +76,172 @@ public class GeneralStatisticsService : IGeneralStatisticsService
     }
 
     /// <summary>
+    /// Get general statistics filtered by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>General statistics data for the department.</returns>
+    public async Task<CustomWebResponse> GetGeneralStatisticsByDepartmentAsync(int departmentId, CancellationToken ct = default)
+    {
+        // Calculate statistics using private methods
+        var totalActiveInitiatives = await GetTotalActiveInitiativesCountByDepartmentAsync(departmentId, ct);
+        var totalPeopleInvolved = await GetTotalPeopleInvolvedCountByDepartmentAsync(departmentId, ct);
+        var totalAreaInHectares = await GetTotalAreaInHectaresByDepartmentAsync(departmentId, ct);
+
+        // Validate data integrity
+        if (totalActiveInitiatives < 0)
+        {
+            return new CustomWebResponse(true)
+            {
+                Message = "Invalid data: negative initiative count",
+            };
+        }
+
+        if (totalPeopleInvolved < 0)
+        {
+            return new CustomWebResponse(true)
+            {
+                Message = "Invalid data: negative people count",
+            };
+        }
+
+        if (totalAreaInHectares < 0)
+        {
+            return new CustomWebResponse(true)
+            {
+                Message = "Invalid data: negative area value",
+            };
+        }
+
+        var statistics = new GeneralStatisticsDto
+        {
+            TotalActiveInitiatives = totalActiveInitiatives,
+            TotalPeopleInvolved = totalPeopleInvolved,
+            TotalAreaInHectares = totalAreaInHectares,
+        };
+
+        return new CustomWebResponse
+        {
+            ResponseBody = statistics,
+        };
+    }
+
+    /// <summary>
+    /// Get general statistics filtered by initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>General statistics data for the initiative.</returns>
+    public async Task<CustomWebResponse> GetGeneralStatisticsByInitiativeAsync(int initiativeId, CancellationToken ct = default)
+    {
+        // Calculate statistics using private methods
+        var totalActiveInitiatives = await GetTotalActiveInitiativesCountByInitiativeAsync(initiativeId, ct);
+        var totalPeopleInvolved = await GetTotalPeopleInvolvedCountByInitiativeAsync(initiativeId, ct);
+        var totalAreaInHectares = await GetTotalAreaInHectaresByInitiativeAsync(initiativeId, ct);
+
+        // Validate data integrity
+        if (totalActiveInitiatives < 0)
+        {
+            return new CustomWebResponse(true)
+            {
+                Message = "Invalid data: negative initiative count",
+            };
+        }
+
+        if (totalPeopleInvolved < 0)
+        {
+            return new CustomWebResponse(true)
+            {
+                Message = "Invalid data: negative people count",
+            };
+        }
+
+        if (totalAreaInHectares < 0)
+        {
+            return new CustomWebResponse(true)
+            {
+                Message = "Invalid data: negative area value",
+            };
+        }
+
+        var statistics = new GeneralStatisticsDto
+        {
+            TotalActiveInitiatives = totalActiveInitiatives,
+            TotalPeopleInvolved = totalPeopleInvolved,
+            TotalAreaInHectares = totalAreaInHectares,
+        };
+
+        return new CustomWebResponse
+        {
+            ResponseBody = statistics,
+        };
+    }
+
+    /// <summary>
+    /// Get total count of active initiatives by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of active initiatives in the department.</returns>
+    private async Task<int> GetTotalActiveInitiativesCountByDepartmentAsync(int departmentId, CancellationToken ct = default) =>
+        await initiativeRepository.GetActiveInitiativesCountByDepartmentAsync(departmentId, ct);
+
+    /// <summary>
+    /// Get total count of people involved in active initiatives by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of people involved in the department.</returns>
+    private async Task<int> GetTotalPeopleInvolvedCountByDepartmentAsync(int departmentId, CancellationToken ct = default) =>
+        await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountByDepartmentAsync(departmentId, ct);
+
+    /// <summary>
+    /// Get total area of active initiatives by department in hectares.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Total area in hectares for the department.</returns>
+    private async Task<double> GetTotalAreaInHectaresByDepartmentAsync(int departmentId, CancellationToken ct = default)
+    {
+        var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesByDepartmentAsync(departmentId, ct);
+
+        // Convert from km² to hectares (1 km² = 100 hectares)
+        return Math.Round(totalAreaInSquareKm * 100, 2);
+    }
+
+    /// <summary>
+    /// Get total count of active initiatives by specific initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of active initiatives (should be 1 or 0).</returns>
+    private async Task<int> GetTotalActiveInitiativesCountByInitiativeAsync(int initiativeId, CancellationToken ct = default) =>
+        await initiativeRepository.GetActiveInitiativesCountByInitiativeAsync(initiativeId, ct);
+
+    /// <summary>
+    /// Get total count of people involved in active initiatives by specific initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of people involved in the initiative.</returns>
+    private async Task<int> GetTotalPeopleInvolvedCountByInitiativeAsync(int initiativeId, CancellationToken ct = default) =>
+        await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountByInitiativeAsync(initiativeId, ct);
+
+    /// <summary>
+    /// Get total area of active initiatives by specific initiative in hectares.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Total area in hectares for the initiative.</returns>
+    private async Task<double> GetTotalAreaInHectaresByInitiativeAsync(int initiativeId, CancellationToken ct = default)
+    {
+        var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesByInitiativeAsync(initiativeId, ct);
+
+        // Convert from km² to hectares (1 km² = 100 hectares)
+        return Math.Round(totalAreaInSquareKm * 100, 2);
+    }
+
+    /// <summary>
     /// Get total count of active initiatives.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Core/Interfaces/Repositories/IInitiativeRepository.cs
+++ b/src/Core/Interfaces/Repositories/IInitiativeRepository.cs
@@ -48,4 +48,52 @@ public interface IInitiativeRepository : IRepository<Initiative>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Count of people involved in active initiatives.</returns>
     public Task<int> GetPeopleInvolvedInActiveInitiativesCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Get count of active initiatives by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of active initiatives in the department.</returns>
+    public Task<int> GetActiveInitiativesCountByDepartmentAsync(int departmentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get total area of active initiatives by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Total area in square kilometers for the department.</returns>
+    public Task<double> GetTotalAreaOfActiveInitiativesByDepartmentAsync(int departmentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get count of people involved in active initiatives by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of people involved in active initiatives in the department.</returns>
+    public Task<int> GetPeopleInvolvedInActiveInitiativesCountByDepartmentAsync(int departmentId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get count of active initiatives by specific initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of active initiatives (should be 1 or 0).</returns>
+    public Task<int> GetActiveInitiativesCountByInitiativeAsync(int initiativeId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get total area of active initiatives by specific initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Total area in square kilometers for the initiative.</returns>
+    public Task<double> GetTotalAreaOfActiveInitiativesByInitiativeAsync(int initiativeId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get count of people involved in active initiatives by specific initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of people involved in the specific initiative.</returns>
+    public Task<int> GetPeopleInvolvedInActiveInitiativesCountByInitiativeAsync(int initiativeId, CancellationToken ct = default);
 }

--- a/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
@@ -86,4 +86,70 @@ public class InitiativeRepository : Repository<Initiative>, IInitiativeRepositor
         await dbContext.InitiativeUsers
             .Where(iu => iu.Initiative.Enabled)
             .CountAsync(ct);
+
+    /// <summary>
+    /// Get count of active initiatives by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of active initiatives in the department.</returns>
+    public async Task<int> GetActiveInitiativesCountByDepartmentAsync(int departmentId, CancellationToken ct = default) =>
+        await dbContext.Initiatives
+            .Where(i => i.Enabled && i.InitiativeLocations.Any(il => il.LocationId == departmentId))
+            .CountAsync(ct);
+
+    /// <summary>
+    /// Get total area of active initiatives by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Total area in square kilometers for the department.</returns>
+    public async Task<double> GetTotalAreaOfActiveInitiativesByDepartmentAsync(int departmentId, CancellationToken ct = default) =>
+        await dbContext.Initiatives
+            .Where(i => i.Enabled && i.PolygonArea > 0 && i.InitiativeLocations.Any(il => il.LocationId == departmentId))
+            .SumAsync(i => i.PolygonArea, ct);
+
+    /// <summary>
+    /// Get count of people involved in active initiatives by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of people involved in active initiatives in the department.</returns>
+    public async Task<int> GetPeopleInvolvedInActiveInitiativesCountByDepartmentAsync(int departmentId, CancellationToken ct = default) =>
+        await dbContext.InitiativeUsers
+            .Where(iu => iu.Initiative.Enabled && iu.Initiative.InitiativeLocations.Any(il => il.LocationId == departmentId))
+            .CountAsync(ct);
+
+    /// <summary>
+    /// Get count of active initiatives by specific initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of active initiatives (should be 1 or 0).</returns>
+    public async Task<int> GetActiveInitiativesCountByInitiativeAsync(int initiativeId, CancellationToken ct = default) =>
+        await dbContext.Initiatives
+            .Where(i => i.Enabled && i.Id == initiativeId)
+            .CountAsync(ct);
+
+    /// <summary>
+    /// Get total area of active initiatives by specific initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Total area in square kilometers for the initiative.</returns>
+    public async Task<double> GetTotalAreaOfActiveInitiativesByInitiativeAsync(int initiativeId, CancellationToken ct = default) =>
+        await dbContext.Initiatives
+            .Where(i => i.Enabled && i.PolygonArea > 0 && i.Id == initiativeId)
+            .SumAsync(i => i.PolygonArea, ct);
+
+    /// <summary>
+    /// Get count of people involved in active initiatives by specific initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Count of people involved in the specific initiative.</returns>
+    public async Task<int> GetPeopleInvolvedInActiveInitiativesCountByInitiativeAsync(int initiativeId, CancellationToken ct = default) =>
+        await dbContext.InitiativeUsers
+            .Where(iu => iu.Initiative.Enabled && iu.InitiativeId == initiativeId)
+            .CountAsync(ct);
 }

--- a/src/WebApi/Controllers/Rest/Reports/GeneralStatisticsController.cs
+++ b/src/WebApi/Controllers/Rest/Reports/GeneralStatisticsController.cs
@@ -3,6 +3,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using IAVH.BioTablero.CM.Application.DTOs.Reports;
 using IAVH.BioTablero.CM.Application.Interfaces.Services;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Reports;
@@ -32,7 +33,10 @@ public class GeneralStatisticsController(
     /// <param name="ct">Cancellation token.</param>
     /// <returns>General statistics data including initiatives, users, join requests, and recent activity.</returns>
     [HttpGet]
+    [ProducesResponseType(typeof(GeneralStatisticsDto), StatusCodes.Status200OK)]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(GeneralStatisticsResponseExample))]
+    [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetGeneralStatistics(CancellationToken ct = default)
     {
         var response = await generalStatisticsService.GetGeneralStatisticsAsync(ct);
@@ -46,7 +50,10 @@ public class GeneralStatisticsController(
     /// <param name="ct">Cancellation token.</param>
     /// <returns>General statistics data for the specified department.</returns>
     [HttpGet("department/{departmentId}")]
+    [ProducesResponseType(typeof(GeneralStatisticsDto), StatusCodes.Status200OK)]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(GeneralStatisticsResponseExample))]
+    [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetGeneralStatisticsByDepartment(int departmentId, CancellationToken ct = default)
     {
         var response = await generalStatisticsService.GetGeneralStatisticsByDepartmentAsync(departmentId, ct);
@@ -60,7 +67,10 @@ public class GeneralStatisticsController(
     /// <param name="ct">Cancellation token.</param>
     /// <returns>General statistics data for the specified initiative.</returns>
     [HttpGet("initiative/{initiativeId}")]
+    [ProducesResponseType(typeof(GeneralStatisticsDto), StatusCodes.Status200OK)]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(GeneralStatisticsResponseExample))]
+    [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(void), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> GetGeneralStatisticsByInitiative(int initiativeId, CancellationToken ct = default)
     {
         var response = await generalStatisticsService.GetGeneralStatisticsByInitiativeAsync(initiativeId, ct);

--- a/src/WebApi/Controllers/Rest/Reports/GeneralStatisticsController.cs
+++ b/src/WebApi/Controllers/Rest/Reports/GeneralStatisticsController.cs
@@ -38,4 +38,32 @@ public class GeneralStatisticsController(
         var response = await generalStatisticsService.GetGeneralStatisticsAsync(ct);
         return webTools.CustomResponse(response);
     }
+
+    /// <summary>
+    /// Get general statistics filtered by department.
+    /// </summary>
+    /// <param name="departmentId">Department identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>General statistics data for the specified department.</returns>
+    [HttpGet("department/{departmentId}")]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(GeneralStatisticsResponseExample))]
+    public async Task<IActionResult> GetGeneralStatisticsByDepartment(int departmentId, CancellationToken ct = default)
+    {
+        var response = await generalStatisticsService.GetGeneralStatisticsByDepartmentAsync(departmentId, ct);
+        return webTools.CustomResponse(response);
+    }
+
+    /// <summary>
+    /// Get general statistics filtered by initiative.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>General statistics data for the specified initiative.</returns>
+    [HttpGet("initiative/{initiativeId}")]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(GeneralStatisticsResponseExample))]
+    public async Task<IActionResult> GetGeneralStatisticsByInitiative(int initiativeId, CancellationToken ct = default)
+    {
+        var response = await generalStatisticsService.GetGeneralStatisticsByInitiativeAsync(initiativeId, ct);
+        return webTools.CustomResponse(response);
+    }
 }


### PR DESCRIPTION
## 🛠️ Changes
Introduces endpoints and service methods to retrieve general statistics filtered by department or initiative. Updates repository interfaces and implementations to support filtered queries for active initiatives, people involved, and area calculations.

## 📝 Associated issues
Resolve [LIB-351](https://linear.app/biodev/issue/LIB-351/monitoreo-comunitario-actualizar-controlador-de-cifras-generales)

