### PR TITLE
Add dedicated email templates and controller endpoints

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -167,23 +167,23 @@ dotnet_diagnostic.SA1204.severity = none
 
 # Remove unused private members
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822
-dotnet_diagnostic.CA1822.severity = error
+dotnet_diagnostic.CA1822.severity = warning
 
 # Remove unused private fields
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1823
-dotnet_diagnostic.CA1823.severity = error
+dotnet_diagnostic.CA1823.severity = warning
 
 # Remove unused local variables
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1804
-dotnet_diagnostic.CA1804.severity = error
+dotnet_diagnostic.CA1804.severity = warning
 
 # Remove unused parameters
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1801
-dotnet_diagnostic.CA1801.severity = error
+dotnet_diagnostic.CA1801.severity = warning
 
 # Remove unused using directives
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005
-dotnet_diagnostic.IDE0005.severity = error
+dotnet_diagnostic.IDE0005.severity = warning
 
 # Remove unused type parameters
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1812
@@ -197,10 +197,6 @@ dotnet_diagnostic.IDE0001.severity = suggestion
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0002
 dotnet_diagnostic.IDE0002.severity = suggestion
 
-# Remove unreachable code
+# Remove unreachable code (example: catch all exceptions)
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1031
 dotnet_diagnostic.CA1031.severity = warning
-
-# Remove unused private methods
-# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1811
-dotnet_diagnostic.CA1811.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -167,20 +167,40 @@ dotnet_diagnostic.SA1204.severity = none
 
 # Remove unused private members
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822
-dotnet_diagnostic.CA1822.severity = warning
+dotnet_diagnostic.CA1822.severity = error
 
 # Remove unused private fields
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1823
-dotnet_diagnostic.CA1823.severity = warning
+dotnet_diagnostic.CA1823.severity = error
 
 # Remove unused local variables
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1804
-dotnet_diagnostic.CA1804.severity = warning
+dotnet_diagnostic.CA1804.severity = error
 
 # Remove unused parameters
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1801
-dotnet_diagnostic.CA1801.severity = warning
+dotnet_diagnostic.CA1801.severity = error
 
 # Remove unused using directives
 # https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0005
-dotnet_diagnostic.IDE0005.severity = warning
+dotnet_diagnostic.IDE0005.severity = error
+
+# Remove unused type parameters
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1812
+dotnet_diagnostic.CA1812.severity = warning
+
+# Simplify names (remove unnecessary usings)
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0001
+dotnet_diagnostic.IDE0001.severity = suggestion
+
+# Simplify member access
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0002
+dotnet_diagnostic.IDE0002.severity = suggestion
+
+# Remove unreachable code
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1031
+dotnet_diagnostic.CA1031.severity = warning
+
+# Remove unused private methods
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1811
+dotnet_diagnostic.CA1811.severity = warning

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -4,10 +4,6 @@ on:
   pull_request:
     branches:
       - develop
-  push:
-    branches:
-      - develop
-      - main
 
 jobs:
   verify-dotnet-code:
@@ -33,7 +29,6 @@ jobs:
           echo "🔍 Analyzing code to detect unused elements..."
           dotnet build --no-incremental \
             -warnaserror \
-            -p:RunAnalyzersDuringBuild=true \
             -p:EnableNETAnalyzers=true \
             -p:EnforceCodeStyleInBuild=true
         continue-on-error: false

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -24,19 +24,16 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Check code format and remove unused usings
+      - name: Check code format and unused usings
         run: dotnet format --verify-no-changes --verbosity diagnostic
         continue-on-error: false
 
       - name: Build with code analysis (detects unused code)
         run: |
-          echo "🔍 Analizando código para detectar elementos no utilizados..."
+          echo "🔍 Analyzing code to detect unused elements..."
           dotnet build --no-incremental \
             -warnaserror \
-            -p:TreatWarningsAsErrors=true \
-            -p:WarningLevel=5 \
             -p:RunAnalyzersDuringBuild=true \
             -p:EnableNETAnalyzers=true \
-            -p:AnalysisLevel=8.0 \
             -p:EnforceCodeStyleInBuild=true
         continue-on-error: false

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - develop
+  push:
+    branches:
+      - develop
+      - main
 
 jobs:
   verify-dotnet-code:
@@ -20,8 +24,19 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Check code format
-        run: dotnet format --verify-no-changes
+      - name: Check code format and remove unused usings
+        run: dotnet format --verify-no-changes --verbosity diagnostic
+        continue-on-error: false
 
-      - name: Build with warnings as errors
-        run: dotnet build --no-incremental -warnaserror
+      - name: Build with code analysis (detects unused code)
+        run: |
+          echo "🔍 Analizando código para detectar elementos no utilizados..."
+          dotnet build --no-incremental \
+            -warnaserror \
+            -p:TreatWarningsAsErrors=true \
+            -p:WarningLevel=5 \
+            -p:RunAnalyzersDuringBuild=true \
+            -p:EnableNETAnalyzers=true \
+            -p:AnalysisLevel=8.0 \
+            -p:EnforceCodeStyleInBuild=true
+        continue-on-error: false

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -315,7 +315,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
                 _ => "miembro",
             };
 
-            var emailData = new DefaultEmailData
+            var emailData = new RoleAssignmentEmailData
             {
                 Address = new(userData.FullName, userData.Email),
                 InitiativeName = initiative.Name,
@@ -353,7 +353,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
     private void SendNotificationUserBanned(ExternalUser userData, Initiative initiative, List<InitiativeUser> leaders, CancellationToken ct = default) => Task.Run(
         async () =>
         {
-            var emailData = new DefaultEmailData
+            var emailData = new UserRemovalEmailData
             {
                 Address = new(userData.FullName, userData.Email),
                 InitiativeName = initiative.Name,

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -325,7 +325,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
 
             var receivers = new CustomEmailAddress[] { emailData.Address };
             CustomEmailAddress[] hiddenReceivers = null;
-            var htmlBody = await webViewTools.RenderViewToStringAsync("Default", emailData);
+            var htmlBody = await webViewTools.RenderViewToStringAsync("RoleAssignment", emailData);
 
             if (leaders?.Count > 0)
             {
@@ -362,7 +362,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
 
             var receivers = new CustomEmailAddress[] { emailData.Address };
             CustomEmailAddress[] hiddenReceivers = null;
-            var htmlBody = await webViewTools.RenderViewToStringAsync("Default", emailData);
+            var htmlBody = await webViewTools.RenderViewToStringAsync("UserRemoval", emailData);
 
             if (leaders?.Count > 0)
             {

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -1,7 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.Application.Services.Initiatives;
 
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -319,8 +318,9 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
             var emailData = new DefaultEmailData
             {
                 Address = new(userData.FullName, userData.Email),
-                Subject = string.Format(CultureInfo.InvariantCulture, "Ahora eres {0} de {1}", newLevelName, initiative.Name),
-                Content = string.Format(CultureInfo.InvariantCulture, "Se te ha asignado el rol de {0} en la iniciativa '{1}' por el usuario '{2}'.", newLevelName, initiative.Name, reviewerUserName),
+                InitiativeName = initiative.Name,
+                LevelName = newLevelName,
+                ReviewerUserName = reviewerUserName,
             };
 
             var receivers = new CustomEmailAddress[] { emailData.Address };
@@ -356,8 +356,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
             var emailData = new DefaultEmailData
             {
                 Address = new(userData.FullName, userData.Email),
-                Subject = string.Format(CultureInfo.InvariantCulture, "Has sido retirado de {0}", initiative.Name),
-                Content = string.Format(CultureInfo.InvariantCulture, "Tu membresía en la iniciativa '{0}' ha sido revocada. Si consideras que se trata de un error solicita unirte de nuevo.", initiative.Name),
+                InitiativeName = initiative.Name,
             };
 
             var receivers = new CustomEmailAddress[] { emailData.Address };

--- a/src/Application/Services/Initiatives/JoinInvitationService.cs
+++ b/src/Application/Services/Initiatives/JoinInvitationService.cs
@@ -1,7 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.Application.Services.Initiatives;
 
 using System;
-using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -212,8 +211,8 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
     {
         var emailData = new DefaultEmailData
         {
-            Subject = string.Format(CultureInfo.InvariantCulture, "Invitación a unirse a {0}", initiative.Name),
-            Content = string.Format(CultureInfo.InvariantCulture, "Has sido invitado a unirte a la iniciativa '{0}'.<br /> {1}.", initiative.Name, emailMessage),
+            InitiativeName = initiative.Name,
+            EmailMessage = emailMessage,
         };
 
         var receivers = emails

--- a/src/Application/Services/Initiatives/JoinInvitationService.cs
+++ b/src/Application/Services/Initiatives/JoinInvitationService.cs
@@ -209,7 +209,7 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
 
     private async Task<bool> SendNotificationJoinInvitation(string[] emails, Initiative initiative, string emailMessage, CancellationToken ct = default)
     {
-        var emailData = new DefaultEmailData
+        var emailData = new JoinInvitationEmailData
         {
             InitiativeName = initiative.Name,
             EmailMessage = emailMessage,

--- a/src/Application/Services/Initiatives/JoinInvitationService.cs
+++ b/src/Application/Services/Initiatives/JoinInvitationService.cs
@@ -220,7 +220,7 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
             .Select(e => new CustomEmailAddress(e))
             .ToArray();
 
-        var htmlBody = await webViewTools.RenderViewToStringAsync("Default", emailData);
+        var htmlBody = await webViewTools.RenderViewToStringAsync("JoinInvitation", emailData);
 
         var response = await emailService.SendEmailAsync(emailData.Subject, receivers, null, htmlBody, ct);
 

--- a/src/Application/Services/Initiatives/JoinRequestService.cs
+++ b/src/Application/Services/Initiatives/JoinRequestService.cs
@@ -345,7 +345,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
                 {
                     Content = emailData.Content,
                 };
-                var htmlBody = await webViewTools.RenderViewToStringAsync("Default", emailObject);
+                var htmlBody = await webViewTools.RenderViewToStringAsync("JoinRequest", emailObject);
 
                 await emailService.SendEmailAsync(emailData.Subject, receivers, hiddenReceivers, htmlBody, ct);
             }
@@ -369,7 +369,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
         };
 
         var receivers = new CustomEmailAddress[] { emailData.Address };
-        var htmlBody = await webViewTools.RenderViewToStringAsync("Default", emailData);
+        var htmlBody = await webViewTools.RenderViewToStringAsync("PendingRequestsReminder", emailData);
 
         await emailService.SendEmailAsync(emailData.Subject, receivers, null, htmlBody, ct);
 

--- a/src/Application/Services/Initiatives/JoinRequestService.cs
+++ b/src/Application/Services/Initiatives/JoinRequestService.cs
@@ -173,7 +173,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
         entity = await entityRepository.AddAsync(entity, ct);
 
         // Send email
-        var emailObject = new DefaultEmailData()
+        var emailObject = new JoinRequestEmailData()
         {
             Address = new(userData.FullName, userData.Email),
             InitiativeName = initiative.Name,
@@ -258,7 +258,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
         var userData = await iamService.GetUserDataAsync(entityData.UserName, ct);
         var initiative = await initiativeRepository.GetByIdAsync(entityData.InitiativeId, ct);
 
-        var emailObject = new DefaultEmailData()
+        var emailObject = new JoinRequestEmailData()
         {
             Address = new(userData.FullName, userData.Email),
             InitiativeName = initiative.Name,
@@ -313,7 +313,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
     /// <param name="initiativeId">Initiative identifier.</param>
     /// <param name="emailData">Email data.</param>
     /// <param name="ct">Cancellation token.</param>
-    private void SendNotificationJoinRequest(int initiativeId, DefaultEmailData emailData, CancellationToken ct = default) => _ = Task.Run(
+    private void SendNotificationJoinRequest(int initiativeId, JoinRequestEmailData emailData, CancellationToken ct = default) => _ = Task.Run(
         async () =>
         {
             var leaders = await initiativeUserRepository.ListAsync(InitiativeUserSpec.LevelSpec(initiativeId, (int)InitiativeUserLevelEnum.Leader), ct);
@@ -348,7 +348,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
     /// <returns>Process result.</returns>
     private async Task<bool> SendNotificationOldPendingRequestsAsync(ExternalUser leaderData, int pendingRequests, CancellationToken ct = default)
     {
-        var emailData = new DefaultEmailData
+        var emailData = new PendingRequestsReminderEmailData
         {
             Address = new(leaderData.FullName, leaderData.Email),
             PendingRequestsCount = pendingRequests,

--- a/src/Application/Services/Initiatives/JoinRequestService.cs
+++ b/src/Application/Services/Initiatives/JoinRequestService.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -177,8 +176,9 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
         var emailObject = new DefaultEmailData()
         {
             Address = new(userData.FullName, userData.Email),
-            Subject = string.Format(CultureInfo.InvariantCulture, "Solicitud de ingreso a '{0}'", initiative.Name),
-            Content = string.Format(CultureInfo.InvariantCulture, "El usuario '{0}' ha realizado una solicitud de acceso para la iniciativa '{1}'", userData.Username, initiative.Name),
+            InitiativeName = initiative.Name,
+            UserName = userData.Username,
+            JoinRequestStatus = "Created",
         };
 
         SendNotificationJoinRequest(entityData.InitiativeId, emailObject, ct);
@@ -261,18 +261,9 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
         var emailObject = new DefaultEmailData()
         {
             Address = new(userData.FullName, userData.Email),
+            InitiativeName = initiative.Name,
+            JoinRequestStatus = entity.StatusId == (int)JoinRequestStatusEnum.Approved ? "Approved" : "Rejected",
         };
-
-        if (entity.StatusId == (int)JoinRequestStatusEnum.Approved)
-        {
-            emailObject.Subject = string.Format(CultureInfo.InvariantCulture, "Solicitud de ingreso a '{0}' aprobada", initiative.Name);
-            emailObject.Content = string.Format(CultureInfo.InvariantCulture, "Bienvenido a '{0}'.<br /> Ya puedes aportar al estado de la biodiversidad de nuestro territorio.", initiative.Name);
-        }
-        else
-        {
-            emailObject.Subject = string.Format(CultureInfo.InvariantCulture, "Solicitud de ingreso a '{0}' rechazada", initiative.Name);
-            emailObject.Content = "Tu solicitud ha sido rechazada. Si consideras que se trata de un error solicita de nuevo.";
-        }
 
         SendNotificationJoinRequest(entityData.InitiativeId, emailObject, ct);
 
@@ -341,11 +332,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
 
                 var receivers = new CustomEmailAddress[] { emailData.Address };
 
-                var emailObject = new DefaultEmailData()
-                {
-                    Content = emailData.Content,
-                };
-                var htmlBody = await webViewTools.RenderViewToStringAsync("JoinRequest", emailObject);
+                var htmlBody = await webViewTools.RenderViewToStringAsync("JoinRequest", emailData);
 
                 await emailService.SendEmailAsync(emailData.Subject, receivers, hiddenReceivers, htmlBody, ct);
             }
@@ -364,8 +351,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int, 
         var emailData = new DefaultEmailData
         {
             Address = new(leaderData.FullName, leaderData.Email),
-            Subject = "Tienes solicitudes de ingreso pendientes de revisión",
-            Content = string.Format(CultureInfo.InvariantCulture, "Tienes <b>{0}</b> solicitudes de ingreso que necesitan tu revisión.", pendingRequests),
+            PendingRequestsCount = pendingRequests,
         };
 
         var receivers = new CustomEmailAddress[] { emailData.Address };

--- a/src/Core/Domain/Utils/Email/DefaultEmailData.cs
+++ b/src/Core/Domain/Utils/Email/DefaultEmailData.cs
@@ -19,4 +19,39 @@ public class DefaultEmailData
     /// Email content (HTML format).
     /// </summary>
     public string Content { get; set; }
+
+    /// <summary>
+    /// Initiative name (for email templates).
+    /// </summary>
+    public string InitiativeName { get; set; }
+
+    /// <summary>
+    /// User name (for email templates).
+    /// </summary>
+    public string UserName { get; set; }
+
+    /// <summary>
+    /// Reviewer user name (for email templates).
+    /// </summary>
+    public string ReviewerUserName { get; set; }
+
+    /// <summary>
+    /// Level name (for email templates).
+    /// </summary>
+    public string LevelName { get; set; }
+
+    /// <summary>
+    /// Email message (for email templates).
+    /// </summary>
+    public string EmailMessage { get; set; }
+
+    /// <summary>
+    /// Pending requests count (for email templates).
+    /// </summary>
+    public int? PendingRequestsCount { get; set; }
+
+    /// <summary>
+    /// Join request status (for email templates): "Created", "Approved", "Rejected".
+    /// </summary>
+    public string JoinRequestStatus { get; set; }
 }

--- a/src/Core/Domain/Utils/Email/DefaultEmailData.cs
+++ b/src/Core/Domain/Utils/Email/DefaultEmailData.cs
@@ -19,39 +19,4 @@ public class DefaultEmailData
     /// Email content (HTML format).
     /// </summary>
     public string Content { get; set; }
-
-    /// <summary>
-    /// Initiative name (for email templates).
-    /// </summary>
-    public string InitiativeName { get; set; }
-
-    /// <summary>
-    /// User name (for email templates).
-    /// </summary>
-    public string UserName { get; set; }
-
-    /// <summary>
-    /// Reviewer user name (for email templates).
-    /// </summary>
-    public string ReviewerUserName { get; set; }
-
-    /// <summary>
-    /// Level name (for email templates).
-    /// </summary>
-    public string LevelName { get; set; }
-
-    /// <summary>
-    /// Email message (for email templates).
-    /// </summary>
-    public string EmailMessage { get; set; }
-
-    /// <summary>
-    /// Pending requests count (for email templates).
-    /// </summary>
-    public int? PendingRequestsCount { get; set; }
-
-    /// <summary>
-    /// Join request status (for email templates): "Created", "Approved", "Rejected".
-    /// </summary>
-    public string JoinRequestStatus { get; set; }
 }

--- a/src/Core/Domain/Utils/Email/JoinInvitationEmailData.cs
+++ b/src/Core/Domain/Utils/Email/JoinInvitationEmailData.cs
@@ -1,0 +1,18 @@
+namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+
+/// <summary>
+/// Join invitation email data.
+/// </summary>
+public class JoinInvitationEmailData : DefaultEmailData
+{
+    /// <summary>
+    /// Initiative name.
+    /// </summary>
+    public string InitiativeName { get; set; }
+
+    /// <summary>
+    /// Email message.
+    /// </summary>
+    public string EmailMessage { get; set; }
+}
+

--- a/src/Core/Domain/Utils/Email/JoinInvitationEmailData.cs
+++ b/src/Core/Domain/Utils/Email/JoinInvitationEmailData.cs
@@ -15,4 +15,3 @@ public class JoinInvitationEmailData : DefaultEmailData
     /// </summary>
     public string EmailMessage { get; set; }
 }
-

--- a/src/Core/Domain/Utils/Email/JoinInvitationEmailData.cs
+++ b/src/Core/Domain/Utils/Email/JoinInvitationEmailData.cs
@@ -1,4 +1,4 @@
-namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
 
 /// <summary>
 /// Join invitation email data.

--- a/src/Core/Domain/Utils/Email/JoinRequestEmailData.cs
+++ b/src/Core/Domain/Utils/Email/JoinRequestEmailData.cs
@@ -20,4 +20,3 @@ public class JoinRequestEmailData : DefaultEmailData
     /// </summary>
     public string JoinRequestStatus { get; set; }
 }
-

--- a/src/Core/Domain/Utils/Email/JoinRequestEmailData.cs
+++ b/src/Core/Domain/Utils/Email/JoinRequestEmailData.cs
@@ -1,0 +1,23 @@
+namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+
+/// <summary>
+/// Join request email data.
+/// </summary>
+public class JoinRequestEmailData : DefaultEmailData
+{
+    /// <summary>
+    /// Initiative name.
+    /// </summary>
+    public string InitiativeName { get; set; }
+
+    /// <summary>
+    /// User name.
+    /// </summary>
+    public string UserName { get; set; }
+
+    /// <summary>
+    /// Join request status: "Created", "Approved", "Rejected".
+    /// </summary>
+    public string JoinRequestStatus { get; set; }
+}
+

--- a/src/Core/Domain/Utils/Email/JoinRequestEmailData.cs
+++ b/src/Core/Domain/Utils/Email/JoinRequestEmailData.cs
@@ -1,4 +1,4 @@
-namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
 
 /// <summary>
 /// Join request email data.

--- a/src/Core/Domain/Utils/Email/PendingRequestsReminderEmailData.cs
+++ b/src/Core/Domain/Utils/Email/PendingRequestsReminderEmailData.cs
@@ -1,4 +1,4 @@
-namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
 
 /// <summary>
 /// Pending requests reminder email data.

--- a/src/Core/Domain/Utils/Email/PendingRequestsReminderEmailData.cs
+++ b/src/Core/Domain/Utils/Email/PendingRequestsReminderEmailData.cs
@@ -10,4 +10,3 @@ public class PendingRequestsReminderEmailData : DefaultEmailData
     /// </summary>
     public int PendingRequestsCount { get; set; }
 }
-

--- a/src/Core/Domain/Utils/Email/PendingRequestsReminderEmailData.cs
+++ b/src/Core/Domain/Utils/Email/PendingRequestsReminderEmailData.cs
@@ -1,0 +1,13 @@
+namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+
+/// <summary>
+/// Pending requests reminder email data.
+/// </summary>
+public class PendingRequestsReminderEmailData : DefaultEmailData
+{
+    /// <summary>
+    /// Pending requests count.
+    /// </summary>
+    public int PendingRequestsCount { get; set; }
+}
+

--- a/src/Core/Domain/Utils/Email/RoleAssignmentEmailData.cs
+++ b/src/Core/Domain/Utils/Email/RoleAssignmentEmailData.cs
@@ -20,4 +20,3 @@ public class RoleAssignmentEmailData : DefaultEmailData
     /// </summary>
     public string ReviewerUserName { get; set; }
 }
-

--- a/src/Core/Domain/Utils/Email/RoleAssignmentEmailData.cs
+++ b/src/Core/Domain/Utils/Email/RoleAssignmentEmailData.cs
@@ -1,0 +1,23 @@
+namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+
+/// <summary>
+/// Role assignment email data.
+/// </summary>
+public class RoleAssignmentEmailData : DefaultEmailData
+{
+    /// <summary>
+    /// Initiative name.
+    /// </summary>
+    public string InitiativeName { get; set; }
+
+    /// <summary>
+    /// Level name.
+    /// </summary>
+    public string LevelName { get; set; }
+
+    /// <summary>
+    /// Reviewer user name.
+    /// </summary>
+    public string ReviewerUserName { get; set; }
+}
+

--- a/src/Core/Domain/Utils/Email/RoleAssignmentEmailData.cs
+++ b/src/Core/Domain/Utils/Email/RoleAssignmentEmailData.cs
@@ -1,4 +1,4 @@
-namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
 
 /// <summary>
 /// Role assignment email data.

--- a/src/Core/Domain/Utils/Email/UserRemovalEmailData.cs
+++ b/src/Core/Domain/Utils/Email/UserRemovalEmailData.cs
@@ -10,4 +10,3 @@ public class UserRemovalEmailData : DefaultEmailData
     /// </summary>
     public string InitiativeName { get; set; }
 }
-

--- a/src/Core/Domain/Utils/Email/UserRemovalEmailData.cs
+++ b/src/Core/Domain/Utils/Email/UserRemovalEmailData.cs
@@ -1,4 +1,4 @@
-namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
 
 /// <summary>
 /// User removal email data.

--- a/src/Core/Domain/Utils/Email/UserRemovalEmailData.cs
+++ b/src/Core/Domain/Utils/Email/UserRemovalEmailData.cs
@@ -1,0 +1,13 @@
+namespace IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+
+/// <summary>
+/// User removal email data.
+/// </summary>
+public class UserRemovalEmailData : DefaultEmailData
+{
+    /// <summary>
+    /// Initiative name.
+    /// </summary>
+    public string InitiativeName { get; set; }
+}
+

--- a/src/WebApi/Controllers/Mvc/EmailTemplatesController.cs
+++ b/src/WebApi/Controllers/Mvc/EmailTemplatesController.cs
@@ -1,8 +1,5 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Mvc;
 
-using System.Linq;
-using System.Threading.Tasks;
-
 using IAVH.BioTablero.CM.Application.Interfaces.ExternalServices;
 using IAVH.BioTablero.CM.Application.Interfaces.Services;
 using IAVH.BioTablero.CM.Core.Domain.Utils.Email;
@@ -48,7 +45,7 @@ public class EmailTemplatesController : Controller
     public IActionResult RoleAssignment(string content = null)
     {
         var model = !string.IsNullOrEmpty(content)
-            ? new DefaultEmailData { Content = content }
+            ? new RoleAssignmentEmailData { Content = content }
             : null;
 
         return View(model);
@@ -64,7 +61,7 @@ public class EmailTemplatesController : Controller
     public IActionResult UserRemoval(string content = null)
     {
         var model = !string.IsNullOrEmpty(content)
-            ? new DefaultEmailData { Content = content }
+            ? new UserRemovalEmailData { Content = content }
             : null;
 
         return View(model);
@@ -80,7 +77,7 @@ public class EmailTemplatesController : Controller
     public IActionResult JoinInvitation(string content = null)
     {
         var model = !string.IsNullOrEmpty(content)
-            ? new DefaultEmailData { Content = content }
+            ? new JoinInvitationEmailData { Content = content }
             : null;
 
         return View(model);
@@ -96,7 +93,7 @@ public class EmailTemplatesController : Controller
     public IActionResult JoinRequest(string content = null)
     {
         var model = !string.IsNullOrEmpty(content)
-            ? new DefaultEmailData { Content = content }
+            ? new JoinRequestEmailData { Content = content }
             : null;
 
         return View(model);
@@ -112,69 +109,9 @@ public class EmailTemplatesController : Controller
     public IActionResult PendingRequestsReminder(string content = null)
     {
         var model = !string.IsNullOrEmpty(content)
-            ? new DefaultEmailData { Content = content }
+            ? new PendingRequestsReminderEmailData { Content = content }
             : null;
 
         return View(model);
-    }
-
-    /// <summary>
-    /// Test email sending with a specific template.
-    /// </summary>
-    /// <param name="template">Template name (RoleAssignment, UserRemoval, JoinInvitation, JoinRequest, PendingRequestsReminder).</param>
-    /// <param name="email">Email address to send test email.</param>
-    /// <param name="content">Email content (HTML format).</param>
-    /// <param name="subject">Email subject.</param>
-    /// <returns>Test result.</returns>
-    [HttpPost]
-    [Route("Test/{template}")]
-    public async Task<IActionResult> TestEmail(string template, string email, string content = null, string subject = null)
-    {
-        if (string.IsNullOrEmpty(email))
-        {
-            return BadRequest(new { error = "Email address is required" });
-        }
-
-        var validTemplates = new[] { "RoleAssignment", "UserRemoval", "JoinInvitation", "JoinRequest", "PendingRequestsReminder" };
-        if (!validTemplates.Contains(template))
-        {
-            return BadRequest(new { error = $"Invalid template. Valid templates: {string.Join(", ", validTemplates)}" });
-        }
-
-        var emailData = new DefaultEmailData
-        {
-            Address = new CustomEmailAddress("Usuario de Prueba", email),
-            Subject = subject ?? $"Prueba de plantilla: {template}",
-            Content = content ?? $"<p>Este es un correo de prueba para la plantilla <b>{template}</b>.</p>",
-        };
-
-        try
-        {
-            var htmlBody = await webViewTools.RenderViewToStringAsync(template, emailData);
-
-            var receivers = new CustomEmailAddress[] { emailData.Address };
-            var response = await emailService.SendEmailAsync(emailData.Subject, receivers, null, htmlBody);
-
-            return Json(new
-            {
-                success = true,
-                message = "Email sent successfully",
-                template = template,
-                email = email,
-                serverResponse = response,
-                htmlBodyLength = htmlBody.Length,
-            });
-        }
-        catch (System.Exception ex)
-        {
-            return StatusCode(500, Json(new
-            {
-                success = false,
-                error = ex.Message,
-                stackTrace = ex.StackTrace,
-                template = template,
-                email = email,
-            }));
-        }
     }
 }

--- a/src/WebApi/Controllers/Mvc/EmailTemplatesController.cs
+++ b/src/WebApi/Controllers/Mvc/EmailTemplatesController.cs
@@ -1,5 +1,13 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Mvc;
 
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using IAVH.BioTablero.CM.Application.Interfaces.ExternalServices;
+using IAVH.BioTablero.CM.Application.Interfaces.Services;
+using IAVH.BioTablero.CM.Core.Domain.Utils.Email;
+
 using Microsoft.AspNetCore.Mvc;
 
 /// <summary>
@@ -9,6 +17,20 @@ using Microsoft.AspNetCore.Mvc;
 [ApiExplorerSettings(IgnoreApi = true)]
 public class EmailTemplatesController : Controller
 {
+    private readonly IWebViewTools webViewTools;
+    private readonly IEmailService emailService;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EmailTemplatesController"/> class.
+    /// </summary>
+    /// <param name="webViewTools">Web view tools service.</param>
+    /// <param name="emailService">Email service.</param>
+    public EmailTemplatesController(IWebViewTools webViewTools, IEmailService emailService)
+    {
+        this.webViewTools = webViewTools;
+        this.emailService = emailService;
+    }
+
     /// <summary>
     /// Get default view.
     /// </summary>
@@ -16,4 +38,164 @@ public class EmailTemplatesController : Controller
     [HttpGet]
     [Route("Default")]
     public IActionResult Default() => View();
+
+    /// <summary>
+    /// Get role assignment view.
+    /// </summary>
+    /// <param name="content">Optional content to preview.</param>
+    /// <returns>Role assignment view.</returns>
+    [HttpGet]
+    [Route("RoleAssignment")]
+    public IActionResult RoleAssignment(string content = null)
+    {
+        var model = !string.IsNullOrEmpty(content)
+            ? new DefaultEmailData { Content = content }
+            : null;
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Get user removal view.
+    /// </summary>
+    /// <param name="content">Optional content to preview.</param>
+    /// <returns>User removal view.</returns>
+    [HttpGet]
+    [Route("UserRemoval")]
+    public IActionResult UserRemoval(string content = null)
+    {
+        var model = !string.IsNullOrEmpty(content)
+            ? new DefaultEmailData { Content = content }
+            : null;
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Get join invitation view.
+    /// </summary>
+    /// <param name="content">Optional content to preview.</param>
+    /// <returns>Join invitation view.</returns>
+    [HttpGet]
+    [Route("JoinInvitation")]
+    public IActionResult JoinInvitation(string content = null)
+    {
+        var model = !string.IsNullOrEmpty(content)
+            ? new DefaultEmailData { Content = content }
+            : null;
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Get join request view.
+    /// </summary>
+    /// <param name="content">Optional content to preview.</param>
+    /// <returns>Join request view.</returns>
+    [HttpGet]
+    [Route("JoinRequest")]
+    public IActionResult JoinRequest(string content = null)
+    {
+        var model = !string.IsNullOrEmpty(content)
+            ? new DefaultEmailData { Content = content }
+            : null;
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Get pending requests reminder view.
+    /// </summary>
+    /// <param name="content">Optional content to preview.</param>
+    /// <returns>Pending requests reminder view.</returns>
+    [HttpGet]
+    [Route("PendingRequestsReminder")]
+    public IActionResult PendingRequestsReminder(string content = null)
+    {
+        var model = !string.IsNullOrEmpty(content)
+            ? new DefaultEmailData { Content = content }
+            : null;
+
+        return View(model);
+    }
+
+    /// <summary>
+    /// Get SMTP configuration (for debugging).
+    /// </summary>
+    /// <returns>SMTP configuration.</returns>
+    [HttpGet]
+    [Route("Config")]
+    [Produces("application/json")]
+    public IActionResult GetSmtpConfig() => Json(new
+    {
+        smtpHost = Environment.GetEnvironmentVariable("SMTP_HOST"),
+        smtpPort = Environment.GetEnvironmentVariable("SMTP_PORT"),
+        smtpEnabledSsl = Environment.GetEnvironmentVariable("SMTP_ENABLED_SSL"),
+        smtpFrom = Environment.GetEnvironmentVariable("SMTP_FROM"),
+        smtpFromName = Environment.GetEnvironmentVariable("SMTP_FROM_NAME"),
+        smtpUser = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SMTP_USER")) ? "empty" : "set",
+        smtpPass = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SMTP_PASS")) ? "empty" : "set",
+    });
+
+    /// <summary>
+    /// Test email sending with a specific template.
+    /// </summary>
+    /// <param name="template">Template name (RoleAssignment, UserRemoval, JoinInvitation, JoinRequest, PendingRequestsReminder).</param>
+    /// <param name="email">Email address to send test email.</param>
+    /// <param name="content">Email content (HTML format).</param>
+    /// <param name="subject">Email subject.</param>
+    /// <returns>Test result.</returns>
+    [HttpPost]
+    [Route("Test/{template}")]
+    public async Task<IActionResult> TestEmail(string template, string email, string content = null, string subject = null)
+    {
+        if (string.IsNullOrEmpty(email))
+        {
+            return BadRequest(new { error = "Email address is required" });
+        }
+
+        var validTemplates = new[] { "RoleAssignment", "UserRemoval", "JoinInvitation", "JoinRequest", "PendingRequestsReminder" };
+        if (!validTemplates.Contains(template))
+        {
+            return BadRequest(new { error = $"Invalid template. Valid templates: {string.Join(", ", validTemplates)}" });
+        }
+
+        var emailData = new DefaultEmailData
+        {
+            Address = new CustomEmailAddress("Usuario de Prueba", email),
+            Subject = subject ?? $"Prueba de plantilla: {template}",
+            Content = content ?? $"<p>Este es un correo de prueba para la plantilla <b>{template}</b>.</p>",
+        };
+
+        try
+        {
+            // Renderizar la plantilla
+            var htmlBody = await webViewTools.RenderViewToStringAsync(template, emailData);
+
+            // Enviar el correo
+            var receivers = new CustomEmailAddress[] { emailData.Address };
+            var response = await emailService.SendEmailAsync(emailData.Subject, receivers, null, htmlBody);
+
+            return Json(new
+            {
+                success = true,
+                message = "Email sent successfully",
+                template = template,
+                email = email,
+                serverResponse = response,
+                htmlBodyLength = htmlBody.Length,
+            });
+        }
+        catch (System.Exception ex)
+        {
+            return StatusCode(500, Json(new
+            {
+                success = false,
+                error = ex.Message,
+                stackTrace = ex.StackTrace,
+                template = template,
+                email = email,
+            }));
+        }
+    }
 }

--- a/src/WebApi/Controllers/Mvc/EmailTemplatesController.cs
+++ b/src/WebApi/Controllers/Mvc/EmailTemplatesController.cs
@@ -1,6 +1,5 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Mvc;
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -120,24 +119,6 @@ public class EmailTemplatesController : Controller
     }
 
     /// <summary>
-    /// Get SMTP configuration (for debugging).
-    /// </summary>
-    /// <returns>SMTP configuration.</returns>
-    [HttpGet]
-    [Route("Config")]
-    [Produces("application/json")]
-    public IActionResult GetSmtpConfig() => Json(new
-    {
-        smtpHost = Environment.GetEnvironmentVariable("SMTP_HOST"),
-        smtpPort = Environment.GetEnvironmentVariable("SMTP_PORT"),
-        smtpEnabledSsl = Environment.GetEnvironmentVariable("SMTP_ENABLED_SSL"),
-        smtpFrom = Environment.GetEnvironmentVariable("SMTP_FROM"),
-        smtpFromName = Environment.GetEnvironmentVariable("SMTP_FROM_NAME"),
-        smtpUser = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SMTP_USER")) ? "empty" : "set",
-        smtpPass = string.IsNullOrEmpty(Environment.GetEnvironmentVariable("SMTP_PASS")) ? "empty" : "set",
-    });
-
-    /// <summary>
     /// Test email sending with a specific template.
     /// </summary>
     /// <param name="template">Template name (RoleAssignment, UserRemoval, JoinInvitation, JoinRequest, PendingRequestsReminder).</param>
@@ -169,10 +150,8 @@ public class EmailTemplatesController : Controller
 
         try
         {
-            // Renderizar la plantilla
             var htmlBody = await webViewTools.RenderViewToStringAsync(template, emailData);
 
-            // Enviar el correo
             var receivers = new CustomEmailAddress[] { emailData.Address };
             var response = await emailService.SendEmailAsync(emailData.Subject, receivers, null, htmlBody);
 

--- a/src/WebApi/Controllers/Mvc/EmailTemplatesController.cs
+++ b/src/WebApi/Controllers/Mvc/EmailTemplatesController.cs
@@ -1,7 +1,5 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Mvc;
 
-using IAVH.BioTablero.CM.Application.Interfaces.ExternalServices;
-using IAVH.BioTablero.CM.Application.Interfaces.Services;
 using IAVH.BioTablero.CM.Core.Domain.Utils.Email;
 
 using Microsoft.AspNetCore.Mvc;
@@ -13,20 +11,6 @@ using Microsoft.AspNetCore.Mvc;
 [ApiExplorerSettings(IgnoreApi = true)]
 public class EmailTemplatesController : Controller
 {
-    private readonly IWebViewTools webViewTools;
-    private readonly IEmailService emailService;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="EmailTemplatesController"/> class.
-    /// </summary>
-    /// <param name="webViewTools">Web view tools service.</param>
-    /// <param name="emailService">Email service.</param>
-    public EmailTemplatesController(IWebViewTools webViewTools, IEmailService emailService)
-    {
-        this.webViewTools = webViewTools;
-        this.emailService = emailService;
-    }
-
     /// <summary>
     /// Get default view.
     /// </summary>

--- a/src/WebApi/Views/EmailTemplates/JoinInvitation.cshtml
+++ b/src/WebApi/Views/EmailTemplates/JoinInvitation.cshtml
@@ -1,4 +1,4 @@
-@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.JoinInvitationEmailData
 @{
     var subject = $"Invitación a unirse a {Model?.InitiativeName}";
     var content = $"Has sido invitado a unirte a la iniciativa '{Model?.InitiativeName}'.<br /> {Model?.EmailMessage}.";

--- a/src/WebApi/Views/EmailTemplates/JoinInvitation.cshtml
+++ b/src/WebApi/Views/EmailTemplates/JoinInvitation.cshtml
@@ -1,6 +1,12 @@
 @model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@{
+    var subject = $"Invitación a unirse a {Model?.InitiativeName}";
+    var content = $"Has sido invitado a unirte a la iniciativa '{Model?.InitiativeName}'.<br /> {Model?.EmailMessage}.";
+    Model.Subject = subject;
+    Model.Content = content;
+}
 
 <div style="margin: auto;width: 20rem;">
     <h2 style="color: #e84a5f;">Invitación a Iniciativa</h2>
-    <p>@Html.Raw(Model?.Content)</p>
+    <p>@Html.Raw(content)</p>
 </div>

--- a/src/WebApi/Views/EmailTemplates/JoinInvitation.cshtml
+++ b/src/WebApi/Views/EmailTemplates/JoinInvitation.cshtml
@@ -1,0 +1,6 @@
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+
+<div style="margin: auto;width: 20rem;">
+    <h2 style="color: #e84a5f;">Invitación a Iniciativa</h2>
+    <p>@Html.Raw(Model?.Content)</p>
+</div>

--- a/src/WebApi/Views/EmailTemplates/JoinRequest.cshtml
+++ b/src/WebApi/Views/EmailTemplates/JoinRequest.cshtml
@@ -1,6 +1,29 @@
 @model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@{
+    string subject;
+    string content;
+    
+    if (Model?.JoinRequestStatus == "Created")
+    {
+        subject = $"Solicitud de ingreso a '{Model?.InitiativeName}'";
+        content = $"El usuario '{Model?.UserName}' ha realizado una solicitud de acceso para la iniciativa '{Model?.InitiativeName}'";
+    }
+    else if (Model?.JoinRequestStatus == "Approved")
+    {
+        subject = $"Solicitud de ingreso a '{Model?.InitiativeName}' aprobada";
+        content = $"Bienvenido a '{Model?.InitiativeName}'.<br /> Ya puedes aportar al estado de la biodiversidad de nuestro territorio.";
+    }
+    else
+    {
+        subject = $"Solicitud de ingreso a '{Model?.InitiativeName}' rechazada";
+        content = "Tu solicitud ha sido rechazada. Si consideras que se trata de un error solicita de nuevo.";
+    }
+    
+    Model.Subject = subject;
+    Model.Content = content;
+}
 
 <div style="margin: auto;width: 20rem;">
     <h2 style="color: #e84a5f;">Solicitud de Ingreso</h2>
-    <p>@Html.Raw(Model?.Content)</p>
+    <p>@Html.Raw(content)</p>
 </div>

--- a/src/WebApi/Views/EmailTemplates/JoinRequest.cshtml
+++ b/src/WebApi/Views/EmailTemplates/JoinRequest.cshtml
@@ -1,4 +1,4 @@
-@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.JoinRequestEmailData
 @{
     string subject;
     string content;

--- a/src/WebApi/Views/EmailTemplates/JoinRequest.cshtml
+++ b/src/WebApi/Views/EmailTemplates/JoinRequest.cshtml
@@ -1,0 +1,6 @@
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+
+<div style="margin: auto;width: 20rem;">
+    <h2 style="color: #e84a5f;">Solicitud de Ingreso</h2>
+    <p>@Html.Raw(Model?.Content)</p>
+</div>

--- a/src/WebApi/Views/EmailTemplates/PendingRequestsReminder.cshtml
+++ b/src/WebApi/Views/EmailTemplates/PendingRequestsReminder.cshtml
@@ -1,0 +1,6 @@
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+
+<div style="margin: auto;width: 20rem;">
+    <h2 style="color: #e84a5f;">Recordatorio de Revisión</h2>
+    <p>@Html.Raw(Model?.Content)</p>
+</div>

--- a/src/WebApi/Views/EmailTemplates/PendingRequestsReminder.cshtml
+++ b/src/WebApi/Views/EmailTemplates/PendingRequestsReminder.cshtml
@@ -1,6 +1,12 @@
 @model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@{
+    var subject = "Tienes solicitudes de ingreso pendientes de revisión";
+    var content = $"Tienes <b>{Model?.PendingRequestsCount}</b> solicitudes de ingreso que necesitan tu revisión.";
+    Model.Subject = subject;
+    Model.Content = content;
+}
 
 <div style="margin: auto;width: 20rem;">
     <h2 style="color: #e84a5f;">Recordatorio de Revisión</h2>
-    <p>@Html.Raw(Model?.Content)</p>
+    <p>@Html.Raw(content)</p>
 </div>

--- a/src/WebApi/Views/EmailTemplates/PendingRequestsReminder.cshtml
+++ b/src/WebApi/Views/EmailTemplates/PendingRequestsReminder.cshtml
@@ -1,4 +1,4 @@
-@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.PendingRequestsReminderEmailData
 @{
     var subject = "Tienes solicitudes de ingreso pendientes de revisión";
     var content = $"Tienes <b>{Model?.PendingRequestsCount}</b> solicitudes de ingreso que necesitan tu revisión.";

--- a/src/WebApi/Views/EmailTemplates/RoleAssignment.cshtml
+++ b/src/WebApi/Views/EmailTemplates/RoleAssignment.cshtml
@@ -1,0 +1,6 @@
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+
+<div style="margin: auto;width: 20rem;">
+    <h2 style="color: #e84a5f;">Asignación de Rol</h2>
+    <p>@Html.Raw(Model?.Content)</p>
+</div>

--- a/src/WebApi/Views/EmailTemplates/RoleAssignment.cshtml
+++ b/src/WebApi/Views/EmailTemplates/RoleAssignment.cshtml
@@ -1,6 +1,12 @@
 @model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@{
+    var subject = $"Ahora eres {Model?.LevelName} de {Model?.InitiativeName}";
+    var content = $"Se te ha asignado el rol de {Model?.LevelName} en la iniciativa '{Model?.InitiativeName}' por el usuario '{Model?.ReviewerUserName}'.";
+    Model.Subject = subject;
+    Model.Content = content;
+}
 
 <div style="margin: auto;width: 20rem;">
     <h2 style="color: #e84a5f;">Asignación de Rol</h2>
-    <p>@Html.Raw(Model?.Content)</p>
+    <p>@Html.Raw(content)</p>
 </div>

--- a/src/WebApi/Views/EmailTemplates/RoleAssignment.cshtml
+++ b/src/WebApi/Views/EmailTemplates/RoleAssignment.cshtml
@@ -1,4 +1,4 @@
-@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.RoleAssignmentEmailData
 @{
     var subject = $"Ahora eres {Model?.LevelName} de {Model?.InitiativeName}";
     var content = $"Se te ha asignado el rol de {Model?.LevelName} en la iniciativa '{Model?.InitiativeName}' por el usuario '{Model?.ReviewerUserName}'.";

--- a/src/WebApi/Views/EmailTemplates/UserRemoval.cshtml
+++ b/src/WebApi/Views/EmailTemplates/UserRemoval.cshtml
@@ -1,4 +1,4 @@
-@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.UserRemovalEmailData
 @{
     var subject = $"Has sido retirado de {Model?.InitiativeName}";
     var content = $"Tu membresía en la iniciativa '{Model?.InitiativeName}' ha sido revocada. Si consideras que se trata de un error solicita unirte de nuevo.";

--- a/src/WebApi/Views/EmailTemplates/UserRemoval.cshtml
+++ b/src/WebApi/Views/EmailTemplates/UserRemoval.cshtml
@@ -1,0 +1,6 @@
+@model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+
+<div style="margin: auto;width: 20rem;">
+    <h2 style="color: #e84a5f;">Notificación de Retiro</h2>
+    <p>@Html.Raw(Model?.Content)</p>
+</div>

--- a/src/WebApi/Views/EmailTemplates/UserRemoval.cshtml
+++ b/src/WebApi/Views/EmailTemplates/UserRemoval.cshtml
@@ -1,6 +1,12 @@
 @model IAVH.BioTablero.CM.Core.Domain.Utils.Email.DefaultEmailData
+@{
+    var subject = $"Has sido retirado de {Model?.InitiativeName}";
+    var content = $"Tu membresía en la iniciativa '{Model?.InitiativeName}' ha sido revocada. Si consideras que se trata de un error solicita unirte de nuevo.";
+    Model.Subject = subject;
+    Model.Content = content;
+}
 
 <div style="margin: auto;width: 20rem;">
     <h2 style="color: #e84a5f;">Notificación de Retiro</h2>
-    <p>@Html.Raw(Model?.Content)</p>
+    <p>@Html.Raw(content)</p>
 </div>


### PR DESCRIPTION
## 🛠️ Changes
Introduced specific Razor views for email templates: RoleAssignment, UserRemoval, JoinInvitation, JoinRequest, and PendingRequestsReminder. Updated services to use these templates instead of the default. Extended EmailTemplatesController with endpoints to preview and test each template, and to fetch SMTP configuration for debugging.

## 📝 Associated issues
Resolve [LIB-393](https://linear.app/biodev/issue/LIB-393/monitoreo-comunitario-cambios-en-la-generacion-de-plantillas)

