### PR TITLE
Recursos de monitoreo comunitario (entidades)

### DIFF
--- a/src/Application/DTOs/Initiatives/InitiativeDto.cs
+++ b/src/Application/DTOs/Initiatives/InitiativeDto.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
 
 /// <summary>

--- a/src/Application/DTOs/Initiatives/TagDto.cs
+++ b/src/Application/DTOs/Initiatives/TagDto.cs
@@ -3,7 +3,7 @@
 using IAVH.BioTablero.CM.Application.DTOs.Utils;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
 
-using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums;
+using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums;
 
 /// <summary>
 /// Tag dto.

--- a/src/Application/DTOs/Tags/TagDto.cs
+++ b/src/Application/DTOs/Tags/TagDto.cs
@@ -1,4 +1,4 @@
-﻿namespace IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Application.DTOs.Tags;
 
 using IAVH.BioTablero.CM.Application.DTOs.Utils;
 using IAVH.BioTablero.CM.Application.Interfaces.General;

--- a/src/Application/Interfaces/Services/Tags/ITagService.cs
+++ b/src/Application/Interfaces/Services/Tags/ITagService.cs
@@ -1,8 +1,8 @@
-﻿namespace IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Application.Interfaces.Services.Tags;
 
-using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 
 /// <summary>
 /// Tag service interface.

--- a/src/Application/Mappings/Initiatives/InitiativeMappings.cs
+++ b/src/Application/Mappings/Initiatives/InitiativeMappings.cs
@@ -4,8 +4,10 @@ using System;
 using System.Linq;
 
 using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 
 /// <summary>
 /// Initiative mappings.

--- a/src/Application/Mappings/Initiatives/TagMappings.cs
+++ b/src/Application/Mappings/Initiatives/TagMappings.cs
@@ -7,7 +7,7 @@ using IAVH.BioTablero.CM.Application.DTOs.Utils;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 
-using TagCategoryEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.TagCategory;
+using TagCategoryEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums.TagCategory;
 
 /// <summary>
 /// Tag mappings.

--- a/src/Application/Mappings/Tags/TagMappings.cs
+++ b/src/Application/Mappings/Tags/TagMappings.cs
@@ -1,11 +1,11 @@
-﻿namespace IAVH.BioTablero.CM.Application.Mappings.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Application.Mappings.Tags;
 
 using System;
 
-using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.DTOs.Utils;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 
 using TagCategoryEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums.TagCategory;
 
@@ -14,11 +14,7 @@ using TagCategoryEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums.TagC
 /// </summary>
 public class TagMappings : IMapper<Tag, TagDto>
 {
-    /// <summary>
-    /// Map from entity to DTO.
-    /// </summary>
-    /// <param name="entity">Entity data.</param>
-    /// <returns>DTO data.</returns>
+    /// <inheritdoc/>
     public TagDto Map(Tag entity)
     {
         ArgumentNullException.ThrowIfNull(entity);
@@ -32,11 +28,7 @@ public class TagMappings : IMapper<Tag, TagDto>
         };
     }
 
-    /// <summary>
-    /// Map from DTO to entity.
-    /// </summary>
-    /// <param name="dto">DTO data.</param>
-    /// <returns>Entity data.</returns>
+    /// <inheritdoc/>
     public Tag Map(TagDto dto)
     {
         ArgumentNullException.ThrowIfNull(dto);

--- a/src/Application/Mappings/Tags/TagMappings.cs
+++ b/src/Application/Mappings/Tags/TagMappings.cs
@@ -23,7 +23,7 @@ public class TagMappings : IMapper<Tag, TagDto>
         {
             Id = entity.Id,
             Name = entity.Name,
-            Url = entity.Url.ToString(),
+            Url = entity.Url?.ToString(),
             Category = new EnumEntityDto<TagCategoryEnum>(entity.CategoryId),
         };
     }

--- a/src/Application/Services/Initiatives/InitiativeLocationService.cs
+++ b/src/Application/Services/Initiatives/InitiativeLocationService.cs
@@ -129,7 +129,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         }
 
         // Validate duplicated entities
-        var capitalizedLocalityName = entityData.Locality.Capitalize();
+        var capitalizedLocalityName = entityData.Locality?.Capitalize();
         var hasDuplicatedEntities = await entityRepository.IsDuplicatedAsync(initiativeId, locationId, capitalizedLocalityName, ct);
 
         if (hasDuplicatedEntities)
@@ -211,7 +211,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         }
 
         // Validate duplicated entities
-        var capitalizedLocalityName = entityData.Locality.Capitalize();
+        var capitalizedLocalityName = entityData.Locality?.Capitalize();
         var hasDuplicatedEntities = await entityRepository.IsDuplicatedAsync(id, entity.InitiativeId, locationId, capitalizedLocalityName, ct);
 
         if (hasDuplicatedEntities)

--- a/src/Application/Services/Initiatives/InitiativeTagService.cs
+++ b/src/Application/Services/Initiatives/InitiativeTagService.cs
@@ -8,6 +8,7 @@ using IAVH.BioTablero.CM.Application.Utils;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Domain.Utils.Constants;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Initiatives;
+using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Tags;
 
 using Serilog;
 
@@ -42,13 +43,7 @@ public class InitiativeTagService : IInitiativeTagService
         this.tagRepository = tagRepository;
     }
 
-    /// <summary>
-    /// Add element.
-    /// </summary>
-    /// <param name="initiativeId">Initiative identifier.</param>
-    /// <param name="tagId">Initiative tag identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Process result.</returns>
+    /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(int initiativeId, int tagId, CancellationToken ct = default)
     {
         // Validate initiative
@@ -99,12 +94,7 @@ public class InitiativeTagService : IInitiativeTagService
         return new CustomWebResponse();
     }
 
-    /// <summary>
-    /// Delete element.
-    /// </summary>
-    /// <param name="id">Element identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Process result.</returns>
+    /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, CancellationToken ct = default)
     {
         // Validate entity

--- a/src/Application/Services/Tag/TagService.cs
+++ b/src/Application/Services/Tag/TagService.cs
@@ -1,4 +1,4 @@
-﻿namespace IAVH.BioTablero.CM.Application.Services.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Application.Services.Tag;
 
 using System;
 using System.Linq;
@@ -7,14 +7,15 @@ using System.Threading.Tasks;
 
 using FluentValidation;
 
-using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
-using IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
+using IAVH.BioTablero.CM.Application.Interfaces.Services.Tags;
 using IAVH.BioTablero.CM.Application.Services.General;
 using IAVH.BioTablero.CM.Application.Utils;
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 using IAVH.BioTablero.CM.Core.Domain.Utils.Constants;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Initiatives;
+using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Tags;
 
 using Serilog;
 
@@ -52,12 +53,7 @@ public class TagService : ServiceRead<Tag, TagDto, int>, ITagService
         this.initiativeRepository = initiativeRepository;
     }
 
-    /// <summary>
-    /// Add element.
-    /// </summary>
-    /// <param name="entityData">Entity data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Process result.</returns>
+    /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(TagDto entityData, CancellationToken ct = default)
     {
         // Validate data
@@ -101,13 +97,7 @@ public class TagService : ServiceRead<Tag, TagDto, int>, ITagService
         };
     }
 
-    /// <summary>
-    /// Update element.
-    /// </summary>
-    /// <param name="id">Element identifier.</param>
-    /// <param name="entityData">Entity data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Process result.</returns>
+    /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, TagDto entityData, CancellationToken ct = default)
     {
         // Validate data
@@ -163,12 +153,7 @@ public class TagService : ServiceRead<Tag, TagDto, int>, ITagService
         };
     }
 
-    /// <summary>
-    /// Delete element.
-    /// </summary>
-    /// <param name="id">Element identifier.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Process result.</returns>
+    /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, CancellationToken ct = default)
     {
         // Validate entity

--- a/src/Application/Services/Tag/TagService.cs
+++ b/src/Application/Services/Tag/TagService.cs
@@ -71,7 +71,7 @@ public class TagService : ServiceRead<Tag, TagDto, int>, ITagService
         }
 
         // Validate duplicated entities
-        var hasDuplicatedEntities = await entityRepository.AnyByName(entityData.Name, ct);
+        var hasDuplicatedEntities = await entityRepository.AnyByNameAndCategory(entityData.Name, entityData.Category.Id, ct);
 
         if (hasDuplicatedEntities)
         {
@@ -126,7 +126,7 @@ public class TagService : ServiceRead<Tag, TagDto, int>, ITagService
         }
 
         // Validate duplicated entities
-        var hasDuplicatedEntities = await entityRepository.IsDuplicated(id, entityData.Name, ct);
+        var hasDuplicatedEntities = await entityRepository.IsDuplicated(id, entityData.Name, entity.CategoryId, ct);
 
         if (hasDuplicatedEntities)
         {
@@ -138,8 +138,7 @@ public class TagService : ServiceRead<Tag, TagDto, int>, ITagService
 
         // Update entity data
         entity.Name = entityData.Name;
-        entity.Url = new Uri(entityData.Url);
-        entity.CategoryId = entityData.Category.Id;
+        entity.Url = entityData.Url != null ? new Uri(entityData.Url) : null;
 
         await entityRepository.UpdateAsync(entity, ct);
 

--- a/src/Application/Validators/Initiatives/TagValidator.cs
+++ b/src/Application/Validators/Initiatives/TagValidator.cs
@@ -5,7 +5,7 @@ using FluentValidation;
 using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
 using IAVH.BioTablero.CM.Core.Domain.Utils.Constants;
 
-using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums;
+using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums;
 
 /// <summary>
 /// Tag validator.

--- a/src/Application/Validators/Tags/TagValidator.cs
+++ b/src/Application/Validators/Tags/TagValidator.cs
@@ -30,14 +30,17 @@ public class TagValidator : AbstractValidator<TagDto>
             .Matches(RegExprConstants.Url)
             .MaximumLength(150);
 
-        RuleFor(dto => dto.Category)
-            .NotNull()
-                .WithMessage("Tag category cannot be null")
-            .ChildRules(level =>
-            {
-                level.RuleFor(tagEnumDto => tagEnumDto.Name)
-                    .IsEnumName(typeof(TagCategory), caseSensitive: false)
-                        .WithMessage("Tag category invalid");
-            });
+        RuleSet("Create", () =>
+        {
+            RuleFor(dto => dto.Category)
+                .NotNull()
+                    .WithMessage("Tag category cannot be null")
+                .ChildRules(level =>
+                {
+                    level.RuleFor(tagEnumDto => tagEnumDto.Name)
+                        .IsEnumName(typeof(TagCategory), caseSensitive: false)
+                            .WithMessage("Tag category invalid");
+                });
+        });
     }
 }

--- a/src/Application/Validators/Tags/TagValidator.cs
+++ b/src/Application/Validators/Tags/TagValidator.cs
@@ -1,8 +1,8 @@
-﻿namespace IAVH.BioTablero.CM.Application.Validators.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Application.Validators.Tags;
 
 using FluentValidation;
 
-using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Core.Domain.Utils.Constants;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums;

--- a/src/Core/Domain/Entities/Initiatives/Initiative.cs
+++ b/src/Core/Domain/Entities/Initiatives/Initiative.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 
 using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
 using IAVH.BioTablero.CM.Core.Domain.Entities.TerritoryStories;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
@@ -75,17 +76,17 @@ public class Initiative : BaseEntity<int>, IAggregateRoot
     public bool Enabled { get; set; }
 
     /// <summary>
-    /// Initiative Locations relationship.
+    /// Initiative Location relationship.
     /// </summary>
     public ICollection<InitiativeLocation> InitiativeLocations { get; init; }
 
     /// <summary>
-    /// Initiative Contacts relationship.
+    /// Initiative Contact relationship.
     /// </summary>
     public ICollection<InitiativeContact> InitiativeContacts { get; init; }
 
     /// <summary>
-    /// Initiative Users relationship.
+    /// Initiative User relationship.
     /// </summary>
     public ICollection<InitiativeUser> InitiativeUsers { get; init; }
 
@@ -95,17 +96,22 @@ public class Initiative : BaseEntity<int>, IAggregateRoot
     public ICollection<InitiativeTag> InitiativeTags { get; init; }
 
     /// <summary>
-    /// Initiative Join Request relationship.
+    /// Join Request relationship.
     /// </summary>
     public ICollection<JoinRequest> JoinRequests { get; init; }
 
     /// <summary>
-    /// Initiative Join Invitations relationship.
+    /// Join Invitation relationship.
     /// </summary>
     public ICollection<JoinInvitation> JoinInvitations { get; init; }
 
     /// <summary>
-    /// Initiative Territory Stories relationship.
+    /// Territory Story relationship.
     /// </summary>
     public ICollection<TerritoryStory> TerritoryStories { get; init; }
+
+    /// <summary>
+    /// Resource relationship.
+    /// </summary>
+    public ICollection<Resource> Resources { get; init; }
 }

--- a/src/Core/Domain/Entities/Initiatives/InitiativeTag.cs
+++ b/src/Core/Domain/Entities/Initiatives/InitiativeTag.cs
@@ -1,5 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
 /// <summary>

--- a/src/Core/Domain/Entities/Initiatives/Tag.cs
+++ b/src/Core/Domain/Entities/Initiatives/Tag.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
 /// <summary>
@@ -34,4 +35,9 @@ public class Tag : BaseEntity<int>, IAggregateRoot
     /// Tag Initiative relationship.
     /// </summary>
     public ICollection<InitiativeTag> TagInitiatives { get; init; }
+
+    /// <summary>
+    /// Tag Resource relationship.
+    /// </summary>
+    public ICollection<ResourceTag> TagResources { get; init; }
 }

--- a/src/Core/Domain/Entities/Resources/Resource.cs
+++ b/src/Core/Domain/Entities/Resources/Resource.cs
@@ -1,0 +1,89 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using System;
+using System.Collections.Generic;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Resource entity.
+/// </summary>
+public class Resource : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Initiative identifier.
+    /// </summary>
+    public int InitiativeId { get; set; }
+
+    /// <summary>
+    /// Resource Type identifier.
+    /// </summary>
+    public int ResourceTypeId { get; set; }
+
+    /// <summary>
+    /// Entity name.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Entity description.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Entity creation date.
+    /// </summary>
+    public DateTime CreationDate { get; set; }
+
+    /// <summary>
+    /// Entity publication date.
+    /// </summary>
+    public DateTime PublicationDate { get; set; }
+
+    /// <summary>
+    /// Is draft flag.
+    /// </summary>
+    public bool IsDraft { get; set; }
+
+    /// <summary>
+    /// Total of resource likes.
+    /// </summary>
+    public int TotalLikes => Likes?.Count ?? 0;
+
+    /// <summary>
+    /// Like action flag for authenticated users.
+    /// </summary>
+    public bool? ILikedIt { get; set; }
+
+    /// <summary>
+    /// Initiative relationship.
+    /// </summary>
+    public Initiative Initiative { get; set; }
+
+    /// <summary>
+    /// Resource Type relationship.
+    /// </summary>
+    public ResourceType ResourceType { get; set; }
+
+    /// <summary>
+    /// Resource Like relationship.
+    /// </summary>
+    public ICollection<ResourceLike> Likes { get; init; }
+
+    /// <summary>
+    /// Resource File relationship.
+    /// </summary>
+    public ICollection<ResourceFile> Files { get; init; }
+
+    /// <summary>
+    /// Resource Link relationship.
+    /// </summary>
+    public ICollection<ResourceLink> Links { get; init; }
+
+    /// <summary>
+    /// Resource Tag relationship.
+    /// </summary>
+    public ICollection<ResourceTag> ResourceTags { get; init; }
+}

--- a/src/Core/Domain/Entities/Resources/ResourceFile.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceFile.cs
@@ -18,7 +18,7 @@ public class ResourceFile : BaseEntity<int>, IAggregateRoot
     /// <summary>
     /// Entity name.
     /// </summary>
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     /// <summary>
     /// Entity URL.

--- a/src/Core/Domain/Entities/Resources/ResourceFile.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceFile.cs
@@ -1,0 +1,32 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using System;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Resource File entity.
+/// </summary>
+public class ResourceFile : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Entity identifier.
+    /// </summary>
+    public int ResourceId { get; set; }
+
+    /// <summary>
+    /// Entity name.
+    /// </summary>
+    public int Name { get; set; }
+
+    /// <summary>
+    /// Entity URL.
+    /// </summary>
+    public Uri Url { get; set; }
+
+    /// <summary>
+    /// Resource relationship.
+    /// </summary>
+    public Resource Resource { get; set; }
+}

--- a/src/Core/Domain/Entities/Resources/ResourceLike.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceLike.cs
@@ -1,0 +1,32 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using System;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Resource Like entity.
+/// </summary>
+public class ResourceLike : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Territory Story identifier.
+    /// </summary>
+    public int TerritoryStoryId { get; set; }
+
+    /// <summary>
+    /// User Name identifier.
+    /// </summary>
+    public string UserName { get; set; }
+
+    /// <summary>
+    /// Entity creation date.
+    /// </summary>
+    public DateTime CreationDate { get; set; }
+
+    /// <summary>
+    /// Resource relationship.
+    /// </summary>
+    public Resource Resource { get; set; }
+}

--- a/src/Core/Domain/Entities/Resources/ResourceLike.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceLike.cs
@@ -11,9 +11,9 @@ using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 public class ResourceLike : BaseEntity<int>, IAggregateRoot
 {
     /// <summary>
-    /// Territory Story identifier.
+    /// Resource identifier.
     /// </summary>
-    public int TerritoryStoryId { get; set; }
+    public int ResourceId { get; set; }
 
     /// <summary>
     /// User Name identifier.

--- a/src/Core/Domain/Entities/Resources/ResourceLink.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceLink.cs
@@ -18,7 +18,7 @@ public class ResourceLink : BaseEntity<int>, IAggregateRoot
     /// <summary>
     /// Entity name.
     /// </summary>
-    public int Name { get; set; }
+    public string Name { get; set; }
 
     /// <summary>
     /// Entity URL.

--- a/src/Core/Domain/Entities/Resources/ResourceLink.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceLink.cs
@@ -1,0 +1,32 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using System;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Resource Link entity.
+/// </summary>
+public class ResourceLink : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Resource identifier.
+    /// </summary>
+    public int ResourceId { get; set; }
+
+    /// <summary>
+    /// Entity name.
+    /// </summary>
+    public int Name { get; set; }
+
+    /// <summary>
+    /// Entity URL.
+    /// </summary>
+    public Uri Url { get; set; }
+
+    /// <summary>
+    /// Resource relationship.
+    /// </summary>
+    public Resource Resource { get; set; }
+}

--- a/src/Core/Domain/Entities/Resources/ResourceTag.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceTag.cs
@@ -1,0 +1,31 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Resource Tag entity.
+/// </summary>
+public class ResourceTag : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Resource identifier.
+    /// </summary>
+    public int ResourceId { get; set; }
+
+    /// <summary>
+    /// Tag identifier.
+    /// </summary>
+    public int TagId { get; set; }
+
+    /// <summary>
+    /// Resource relationship.
+    /// </summary>
+    public Resource Resource { get; set; }
+
+    /// <summary>
+    /// Tag relationship.
+    /// </summary>
+    public Tag Tag { get; set; }
+}

--- a/src/Core/Domain/Entities/Resources/ResourceTag.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceTag.cs
@@ -1,7 +1,7 @@
 ﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
 
 using IAVH.BioTablero.CM.Core.Domain.Entities;
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
 /// <summary>

--- a/src/Core/Domain/Entities/Resources/ResourceType.cs
+++ b/src/Core/Domain/Entities/Resources/ResourceType.cs
@@ -1,0 +1,27 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using System.Collections.Generic;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Resource Type entity.
+/// </summary>
+public class ResourceType : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Entity name.
+    /// </summary>
+    public string Name { get; set; }
+
+    /// <summary>
+    /// Entity description.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Resource relationship.
+    /// </summary>
+    public ICollection<Resource> Resources { get; init; }
+}

--- a/src/Core/Domain/Entities/Tags/Tag.cs
+++ b/src/Core/Domain/Entities/Tags/Tag.cs
@@ -1,8 +1,9 @@
-﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 
 using System;
 using System.Collections.Generic;
 
+using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 

--- a/src/Core/Domain/Entities/Tags/TagCategory.cs
+++ b/src/Core/Domain/Entities/Tags/TagCategory.cs
@@ -1,4 +1,4 @@
-﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 
 using System.Collections.Generic;
 

--- a/src/Core/Domain/Utils/Enums/InitiativesEnums.cs
+++ b/src/Core/Domain/Utils/Enums/InitiativesEnums.cs
@@ -43,22 +43,6 @@ public static class InitiativesEnums
     }
 
     /// <summary>
-    /// Initiative tag category.
-    /// </summary>
-    public enum TagCategory
-    {
-        /// <summary>
-        /// Political context category.
-        /// </summary>
-        PoliticalContext = 1,
-
-        /// <summary>
-        /// Social context category.
-        /// </summary>
-        SocialContext,
-    }
-
-    /// <summary>
     /// Initiative join request status.
     /// </summary>
     public enum JoinRequestStatus

--- a/src/Core/Domain/Utils/Enums/TagEnums.cs
+++ b/src/Core/Domain/Utils/Enums/TagEnums.cs
@@ -1,0 +1,41 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Utils.Enums;
+
+/// <summary>
+/// Tag enumerations.
+/// </summary>
+public static class TagEnums
+{
+    /// <summary>
+    /// Tag category.
+    /// </summary>
+    public enum TagCategory
+    {
+        #region Initiatives
+
+        /// <summary>
+        /// Political context category.
+        /// </summary>
+        PoliticalContext = 1,
+
+        /// <summary>
+        /// Social context category.
+        /// </summary>
+        SocialContext = 2,
+
+        #endregion
+
+        #region Resources
+
+        /// <summary>
+        /// Biological group category.
+        /// </summary>
+        BiologicalGroup = 3,
+
+        /// <summary>
+        /// Ecosystem category.
+        /// </summary>
+        Ecosystem = 4,
+
+        #endregion
+    }
+}

--- a/src/Core/Interfaces/Repositories/Tags/ITagRepository.cs
+++ b/src/Core/Interfaces/Repositories/Tags/ITagRepository.cs
@@ -11,19 +11,21 @@ using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 public interface ITagRepository : IRepository<Tag, int>
 {
     /// <summary>
-    /// Get if elements exists by name.
+    /// Get if elements exists by name and category.
     /// </summary>
     /// <param name="name">Entity name.</param>
+    /// <param name="categoryId">Tag Category identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if any element exists. False otherwise.</returns>
-    Task<bool> AnyByName(string name, CancellationToken ct = default);
+    Task<bool> AnyByNameAndCategory(string name, int categoryId, CancellationToken ct = default);
 
     /// <summary>
     /// Get if element is duplicated.
     /// </summary>
     /// <param name="id">Entity identifier.</param>
     /// <param name="name">Entity name.</param>
+    /// <param name="categoryId">Tag Category identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if any element exists. False otherwise.</returns>
-    Task<bool> IsDuplicated(int id, string name, CancellationToken ct = default);
+    Task<bool> IsDuplicated(int id, string name, int categoryId, CancellationToken ct = default);
 }

--- a/src/Core/Interfaces/Repositories/Tags/ITagRepository.cs
+++ b/src/Core/Interfaces/Repositories/Tags/ITagRepository.cs
@@ -1,9 +1,9 @@
-﻿namespace IAVH.BioTablero.CM.Core.Interfaces.Repositories.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Core.Interfaces.Repositories.Tags;
 
 using System.Threading;
 using System.Threading.Tasks;
 
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 
 /// <summary>
 /// Tag repository interface.

--- a/src/Infrastructure/Persistence/Config/Entities/Initiatives/InitiativeTagConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Initiatives/InitiativeTagConfig.cs
@@ -39,5 +39,9 @@ public class InitiativeTagConfig : IEntityTypeConfiguration<InitiativeTag>
         builder.HasOne(e => e.Initiative)
             .WithMany(p => p.InitiativeTags)
             .HasForeignKey(e => e.InitiativeId);
+
+        builder
+            .HasIndex(e => new { e.InitiativeId, e.TagId })
+            .IsUnique();
     }
 }

--- a/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceConfig.cs
@@ -1,0 +1,67 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Resources;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Resource entity configuration.
+/// </summary>
+public class ResourceConfig : IEntityTypeConfiguration<Resource>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<Resource> builder)
+    {
+        builder.ToTable("resource", "initiatives");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.InitiativeId)
+            .HasColumnName("initiative_id")
+            .IsRequired();
+
+        builder.Property(i => i.ResourceTypeId)
+            .HasColumnName("resource_type_id")
+            .IsRequired();
+
+        builder.Property(i => i.Name)
+            .HasColumnName("name")
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(i => i.Description)
+            .HasColumnName("description")
+            .HasMaxLength(500)
+            .IsRequired();
+
+        builder.Property(e => e.CreationDate)
+            .HasColumnName("creation_date")
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .IsRequired();
+
+        builder.Property(e => e.PublicationDate)
+            .HasColumnName("publication_date");
+
+        builder.Property(i => i.IsDraft)
+            .HasColumnName("is_draft")
+            .HasDefaultValue(true)
+            .IsRequired();
+
+        builder.Ignore(i => i.TotalLikes);
+
+        builder.Ignore(i => i.ILikedIt);
+
+        builder.HasOne(e => e.Initiative)
+            .WithMany(p => p.Resources)
+            .HasForeignKey(e => e.InitiativeId);
+
+        builder
+            .HasIndex(e => e.Name)
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceFileConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceFileConfig.cs
@@ -1,0 +1,46 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Resources;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Resource File entity configuration.
+/// </summary>
+public class ResourceFileConfig : IEntityTypeConfiguration<ResourceFile>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<ResourceFile> builder)
+    {
+        builder.ToTable("resource_file", "initiatives");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.Name)
+            .HasColumnName("name")
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(i => i.Url)
+            .HasColumnName("url")
+            .HasMaxLength(250)
+            .IsRequired();
+
+        builder.Property(i => i.ResourceId)
+            .HasColumnName("resource_id")
+            .IsRequired();
+
+        builder.HasOne(e => e.Resource)
+            .WithMany(p => p.Files)
+            .HasForeignKey(e => e.ResourceId);
+
+        builder
+            .HasIndex(e => new { e.ResourceId, e.Url })
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceLikeConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceLikeConfig.cs
@@ -1,0 +1,46 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Resources;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Resource Like entity configuration.
+/// </summary>
+public class ResourceLikeConfig : IEntityTypeConfiguration<ResourceLike>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<ResourceLike> builder)
+    {
+        builder.ToTable("resource_like", "initiatives");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.ResourceId)
+            .HasColumnName("resource_id")
+            .IsRequired();
+
+        builder.Property(i => i.UserName)
+            .HasColumnName("user_name")
+            .HasMaxLength(75)
+            .IsRequired();
+
+        builder.Property(e => e.CreationDate)
+            .HasColumnName("creation_date")
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .IsRequired();
+
+        builder.HasOne(e => e.Resource)
+            .WithMany(p => p.Likes)
+            .HasForeignKey(e => e.ResourceId);
+
+        builder
+            .HasIndex(e => new { e.ResourceId, e.UserName })
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceLinkConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceLinkConfig.cs
@@ -1,0 +1,46 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Resources;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Resource Link entity configuration.
+/// </summary>
+public class ResourceLinkConfig : IEntityTypeConfiguration<ResourceLink>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<ResourceLink> builder)
+    {
+        builder.ToTable("resource_link", "initiatives");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.Name)
+            .HasColumnName("name")
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(i => i.Url)
+            .HasColumnName("url")
+            .HasMaxLength(250)
+            .IsRequired();
+
+        builder.Property(i => i.ResourceId)
+            .HasColumnName("resource_id")
+            .IsRequired();
+
+        builder.HasOne(e => e.Resource)
+            .WithMany(p => p.Links)
+            .HasForeignKey(e => e.ResourceId);
+
+        builder
+            .HasIndex(e => new { e.ResourceId, e.Url })
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceTagConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceTagConfig.cs
@@ -1,0 +1,44 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Resources;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Resource Tag entity configuration.
+/// </summary>
+public class ResourceTagConfig : IEntityTypeConfiguration<ResourceTag>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<ResourceTag> builder)
+    {
+        builder.ToTable("resource_tag", "initiatives");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.TagId)
+            .HasColumnName("tag_id")
+            .IsRequired();
+
+        builder.Property(i => i.ResourceId)
+            .HasColumnName("resource_id")
+            .IsRequired();
+
+        builder.HasOne(e => e.Tag)
+            .WithMany(p => p.TagResources)
+            .HasForeignKey(e => e.TagId);
+
+        builder.HasOne(e => e.Resource)
+            .WithMany(p => p.ResourceTags)
+            .HasForeignKey(e => e.ResourceId);
+
+        builder
+            .HasIndex(e => new { e.ResourceId, e.TagId })
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceTypeConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceTypeConfig.cs
@@ -1,0 +1,37 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Resources;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Resource Type entity configuration.
+/// </summary>
+public class ResourceTypeConfig : IEntityTypeConfiguration<ResourceType>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<ResourceType> builder)
+    {
+        builder.ToTable("resource_type", "initiatives");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.Name)
+            .HasColumnName("name")
+            .HasMaxLength(50)
+            .IsRequired();
+
+        builder.Property(i => i.Description)
+            .HasColumnName("description")
+            .HasMaxLength(500);
+
+        builder
+            .HasIndex(e => e.Name)
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Tags/TagCategoryConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Tags/TagCategoryConfig.cs
@@ -1,6 +1,6 @@
-﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Tags;
 
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -10,10 +10,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 /// </summary>
 public class TagCategoryConfig : IEntityTypeConfiguration<TagCategory>
 {
-    /// <summary>
-    /// Configure entity.
-    /// </summary>
-    /// <param name="builder">Entity builder.</param>
+    /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<TagCategory> builder)
     {
         builder.ToTable("tag_category", "initiatives");

--- a/src/Infrastructure/Persistence/Config/Entities/Tags/TagConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Tags/TagConfig.cs
@@ -1,6 +1,6 @@
-﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Tags;
 
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
@@ -10,10 +10,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 /// </summary>
 public class TagConfig : IEntityTypeConfiguration<Tag>
 {
-    /// <summary>
-    /// Configure entity.
-    /// </summary>
-    /// <param name="builder">Entity builder.</param>
+    /// <inheritdoc/>
     public void Configure(EntityTypeBuilder<Tag> builder)
     {
         builder.ToTable("tag", "initiatives");

--- a/src/Infrastructure/Persistence/Config/Entities/Tags/TagConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Tags/TagConfig.cs
@@ -39,7 +39,7 @@ public class TagConfig : IEntityTypeConfiguration<Tag>
             .HasForeignKey(e => e.CategoryId);
 
         builder
-            .HasIndex(e => e.Name)
+            .HasIndex(e => new { e.Name, e.CategoryId })
             .IsUnique();
     }
 }

--- a/src/Infrastructure/Persistence/GeneralContext.cs
+++ b/src/Infrastructure/Persistence/GeneralContext.cs
@@ -9,6 +9,7 @@ using IAVH.BioTablero.CM.Core.Domain.Entities.Geo;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Logging;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 using IAVH.BioTablero.CM.Core.Domain.Entities.TerritoryStories;
 
 using Microsoft.EntityFrameworkCore;

--- a/src/Infrastructure/Persistence/GeneralContext.cs
+++ b/src/Infrastructure/Persistence/GeneralContext.cs
@@ -8,13 +8,14 @@ using System.Reflection;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Geo;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Logging;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
 using IAVH.BioTablero.CM.Core.Domain.Entities.TerritoryStories;
 
 using Microsoft.EntityFrameworkCore;
 
 using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
 using JoinRequestStatusEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.JoinRequestStatus;
-using TagCategoryEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.TagCategory;
+using TagCategoryEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums.TagCategory;
 
 /// <summary>
 /// General database context.
@@ -143,6 +144,40 @@ public sealed class GeneralContext : DbContext
 
     #endregion
 
+    #region Resource entities
+
+    /// <summary>
+    /// Resource DbSet.
+    /// </summary>
+    public DbSet<Resource> Resources { get; set; }
+
+    /// <summary>
+    /// Resource Type DbSet.
+    /// </summary>
+    public DbSet<ResourceType> ResourceTypes { get; set; }
+
+    /// <summary>
+    /// Resource File DbSet.
+    /// </summary>
+    public DbSet<ResourceFile> ResourceFiles { get; set; }
+
+    /// <summary>
+    /// Resource Link DbSet.
+    /// </summary>
+    public DbSet<ResourceLink> ResourceLinks { get; set; }
+
+    /// <summary>
+    /// Resource Tag DbSet.
+    /// </summary>
+    public DbSet<ResourceTag> ResourceTags { get; set; }
+
+    /// <summary>
+    /// Resource Like DbSet.
+    /// </summary>
+    public DbSet<ResourceLike> ResourceLikes { get; set; }
+
+    #endregion
+
     /// <summary>
     /// Configure conventions for custom DbContext.
     /// </summary>
@@ -153,12 +188,29 @@ public sealed class GeneralContext : DbContext
         modelBuilder?.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
 
         // Seeding data
+        modelBuilder.Entity<TagCategory>().HasData(GetDefaultTagCategories());
         modelBuilder.Entity<InitiativeUserLevel>().HasData(GetDefaultInitiativeUserLevels());
-        modelBuilder.Entity<TagCategory>().HasData(GetDefaultInitiativeTagCategories());
         modelBuilder.Entity<JoinRequestStatus>().HasData(GetDefaultJoinRequestStatuses());
     }
 
     #region Seeding functions
+
+    #region Tags data
+
+    /// <summary>
+    /// Get default tag categories.
+    /// </summary>
+    /// <returns>Default tag categories list.</returns>
+    private static IEnumerable<TagCategory> GetDefaultTagCategories()
+    {
+        var enumData = Enum.GetValues(typeof(TagCategoryEnum))
+            .Cast<TagCategoryEnum>()
+            .Select(t => new TagCategory() { Id = (int)t, Name = t.ToString() });
+
+        return enumData;
+    }
+
+    #endregion
 
     #region Initiatives data
 
@@ -171,19 +223,6 @@ public sealed class GeneralContext : DbContext
         var enumData = Enum.GetValues(typeof(InitiativeUserLevelEnum))
             .Cast<InitiativeUserLevelEnum>()
             .Select(t => new InitiativeUserLevel() { Id = (int)t, Name = t.ToString() });
-
-        return enumData;
-    }
-
-    /// <summary>
-    /// Get default initative tag categories.
-    /// </summary>
-    /// <returns>Default initative tag categories list.</returns>
-    private static IEnumerable<TagCategory> GetDefaultInitiativeTagCategories()
-    {
-        var enumData = Enum.GetValues(typeof(TagCategoryEnum))
-            .Cast<TagCategoryEnum>()
-            .Select(t => new TagCategory() { Id = (int)t, Name = t.ToString() });
 
         return enumData;
     }

--- a/src/Infrastructure/Persistence/Migrations/20251212232929_UpdateInitiativesAndTags.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20251212232929_UpdateInitiativesAndTags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20251212232929_UpdateInitiativesAndTags")]
+    partial class UpdateInitiativesAndTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20251212232929_UpdateInitiativesAndTags.cs
+++ b/src/Infrastructure/Persistence/Migrations/20251212232929_UpdateInitiativesAndTags.cs
@@ -1,0 +1,64 @@
+﻿#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class UpdateInitiativesAndTags : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_initiative_tag_initiative_id",
+            schema: "initiatives",
+            table: "initiative_tag");
+
+        migrationBuilder.InsertData(
+            schema: "initiatives",
+            table: "tag_category",
+            columns: new[] { "id", "name" },
+            values: new object[,]
+            {
+                { 3, "BiologicalGroup" },
+                { 4, "Ecosystem" },
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_initiative_tag_initiative_id_tag_id",
+            schema: "initiatives",
+            table: "initiative_tag",
+            columns: new[] { "initiative_id", "tag_id" },
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_initiative_tag_initiative_id_tag_id",
+            schema: "initiatives",
+            table: "initiative_tag");
+
+        migrationBuilder.DeleteData(
+            schema: "initiatives",
+            table: "tag_category",
+            keyColumn: "id",
+            keyValue: 3);
+
+        migrationBuilder.DeleteData(
+            schema: "initiatives",
+            table: "tag_category",
+            keyColumn: "id",
+            keyValue: 4);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_initiative_tag_initiative_id",
+            schema: "initiatives",
+            table: "initiative_tag",
+            column: "initiative_id");
+    }
+}

--- a/src/Infrastructure/Persistence/Migrations/20251216203849_FixTagUniqueRules.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20251216203849_FixTagUniqueRules.Designer.cs
@@ -5,6 +5,7 @@ using IAVH.BioTablero.CM.Infrastructure.Persistence;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 using NetTopologySuite.Geometries;
@@ -16,9 +17,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20251216203849_FixTagUniqueRules")]
+    partial class FixTagUniqueRules
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20251216203849_FixTagUniqueRules.cs
+++ b/src/Infrastructure/Persistence/Migrations/20251216203849_FixTagUniqueRules.cs
@@ -1,0 +1,41 @@
+﻿#nullable disable
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class FixTagUniqueRules : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_tag_name",
+            schema: "initiatives",
+            table: "tag");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_tag_name_tag_category_id",
+            schema: "initiatives",
+            table: "tag",
+            columns: new[] { "name", "tag_category_id" },
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_tag_name_tag_category_id",
+            schema: "initiatives",
+            table: "tag");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_tag_name",
+            schema: "initiatives",
+            table: "tag",
+            column: "name",
+            unique: true);
+    }
+}

--- a/src/Infrastructure/Persistence/Migrations/20251216211407_AddResources.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20251216211407_AddResources.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20251216211407_AddResources")]
+    partial class AddResources
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20251216211407_AddResources.cs
+++ b/src/Infrastructure/Persistence/Migrations/20251216211407_AddResources.cs
@@ -1,0 +1,252 @@
+﻿#nullable disable
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+/// <inheritdoc />
+public partial class AddResources : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "resource_type",
+            schema: "initiatives",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                name = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_resource_type", x => x.id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "resource",
+            schema: "initiatives",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                initiative_id = table.Column<int>(type: "integer", nullable: false),
+                resource_type_id = table.Column<int>(type: "integer", nullable: false),
+                name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                creation_date = table.Column<DateTime>(type: "timestamp without time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                publication_date = table.Column<DateTime>(type: "timestamp without time zone", nullable: false),
+                is_draft = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_resource", x => x.id);
+                table.ForeignKey(
+                    name: "FK_resource_initiative_initiative_id",
+                    column: x => x.initiative_id,
+                    principalSchema: "initiatives",
+                    principalTable: "initiative",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_resource_resource_type_resource_type_id",
+                    column: x => x.resource_type_id,
+                    principalSchema: "initiatives",
+                    principalTable: "resource_type",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "resource_file",
+            schema: "initiatives",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                resource_id = table.Column<int>(type: "integer", nullable: false),
+                name = table.Column<int>(type: "integer", maxLength: 100, nullable: false),
+                url = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_resource_file", x => x.id);
+                table.ForeignKey(
+                    name: "FK_resource_file_resource_resource_id",
+                    column: x => x.resource_id,
+                    principalSchema: "initiatives",
+                    principalTable: "resource",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "resource_like",
+            schema: "initiatives",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                resource_id = table.Column<int>(type: "integer", nullable: false),
+                user_name = table.Column<string>(type: "character varying(75)", maxLength: 75, nullable: false),
+                creation_date = table.Column<DateTime>(type: "timestamp without time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_resource_like", x => x.id);
+                table.ForeignKey(
+                    name: "FK_resource_like_resource_resource_id",
+                    column: x => x.resource_id,
+                    principalSchema: "initiatives",
+                    principalTable: "resource",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "resource_link",
+            schema: "initiatives",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                resource_id = table.Column<int>(type: "integer", nullable: false),
+                name = table.Column<int>(type: "integer", maxLength: 100, nullable: false),
+                url = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_resource_link", x => x.id);
+                table.ForeignKey(
+                    name: "FK_resource_link_resource_resource_id",
+                    column: x => x.resource_id,
+                    principalSchema: "initiatives",
+                    principalTable: "resource",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "resource_tag",
+            schema: "initiatives",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                resource_id = table.Column<int>(type: "integer", nullable: false),
+                tag_id = table.Column<int>(type: "integer", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_resource_tag", x => x.id);
+                table.ForeignKey(
+                    name: "FK_resource_tag_resource_resource_id",
+                    column: x => x.resource_id,
+                    principalSchema: "initiatives",
+                    principalTable: "resource",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_resource_tag_tag_tag_id",
+                    column: x => x.tag_id,
+                    principalSchema: "initiatives",
+                    principalTable: "tag",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_initiative_id",
+            schema: "initiatives",
+            table: "resource",
+            column: "initiative_id");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_name",
+            schema: "initiatives",
+            table: "resource",
+            column: "name",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_resource_type_id",
+            schema: "initiatives",
+            table: "resource",
+            column: "resource_type_id");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_file_resource_id_url",
+            schema: "initiatives",
+            table: "resource_file",
+            columns: new[] { "resource_id", "url" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_like_resource_id_user_name",
+            schema: "initiatives",
+            table: "resource_like",
+            columns: new[] { "resource_id", "user_name" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_link_resource_id_url",
+            schema: "initiatives",
+            table: "resource_link",
+            columns: new[] { "resource_id", "url" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_tag_resource_id_tag_id",
+            schema: "initiatives",
+            table: "resource_tag",
+            columns: new[] { "resource_id", "tag_id" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_tag_tag_id",
+            schema: "initiatives",
+            table: "resource_tag",
+            column: "tag_id");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_resource_type_name",
+            schema: "initiatives",
+            table: "resource_type",
+            column: "name",
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "resource_file",
+            schema: "initiatives");
+
+        migrationBuilder.DropTable(
+            name: "resource_like",
+            schema: "initiatives");
+
+        migrationBuilder.DropTable(
+            name: "resource_link",
+            schema: "initiatives");
+
+        migrationBuilder.DropTable(
+            name: "resource_tag",
+            schema: "initiatives");
+
+        migrationBuilder.DropTable(
+            name: "resource",
+            schema: "initiatives");
+
+        migrationBuilder.DropTable(
+            name: "resource_type",
+            schema: "initiatives");
+    }
+}

--- a/src/Infrastructure/Persistence/Migrations/20251222181222_AddResources.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20251222181222_AddResources.Designer.cs
@@ -13,7 +13,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    [Migration("20251216211407_AddResources")]
+    [Migration("20251222181222_AddResources")]
     partial class AddResources
     {
         /// <inheritdoc />
@@ -632,9 +632,10 @@ namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("Name")
+                    b.Property<string>("Name")
+                        .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("integer")
+                        .HasColumnType("character varying(100)")
                         .HasColumnName("name");
 
                     b.Property<int>("ResourceId")
@@ -697,9 +698,10 @@ namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("Name")
+                    b.Property<string>("Name")
+                        .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("integer")
+                        .HasColumnType("character varying(100)")
                         .HasColumnName("name");
 
                     b.Property<int>("ResourceId")

--- a/src/Infrastructure/Persistence/Migrations/20251222181222_AddResources.cs
+++ b/src/Infrastructure/Persistence/Migrations/20251222181222_AddResources.cs
@@ -71,7 +71,7 @@ public partial class AddResources : Migration
                 id = table.Column<int>(type: "integer", nullable: false)
                     .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                 resource_id = table.Column<int>(type: "integer", nullable: false),
-                name = table.Column<int>(type: "integer", maxLength: 100, nullable: false),
+                name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                 url = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
             },
             constraints: table =>
@@ -117,7 +117,7 @@ public partial class AddResources : Migration
                 id = table.Column<int>(type: "integer", nullable: false)
                     .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                 resource_id = table.Column<int>(type: "integer", nullable: false),
-                name = table.Column<int>(type: "integer", maxLength: 100, nullable: false),
+                name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
                 url = table.Column<string>(type: "character varying(250)", maxLength: 250, nullable: false),
             },
             constraints: table =>

--- a/src/Infrastructure/Persistence/Migrations/GeneralContextModelSnapshot.cs
+++ b/src/Infrastructure/Persistence/Migrations/GeneralContextModelSnapshot.cs
@@ -629,9 +629,10 @@ namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("Name")
+                    b.Property<string>("Name")
+                        .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("integer")
+                        .HasColumnType("character varying(100)")
                         .HasColumnName("name");
 
                     b.Property<int>("ResourceId")
@@ -694,9 +695,10 @@ namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
-                    b.Property<int>("Name")
+                    b.Property<string>("Name")
+                        .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("integer")
+                        .HasColumnType("character varying(100)")
                         .HasColumnName("name");
 
                     b.Property<int>("ResourceId")

--- a/src/Infrastructure/Persistence/Repositories/Tags/TagRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Tags/TagRepository.cs
@@ -24,14 +24,14 @@ public class TagRepository : Repository<Tag, int>, ITagRepository
     }
 
     /// <inheritdoc/>
-    public async Task<bool> AnyByName(string name, CancellationToken ct = default) =>
+    public async Task<bool> AnyByNameAndCategory(string name, int categoryId, CancellationToken ct = default) =>
         await dbContext.Tags
-            .Where(e => e.Name == name)
+            .Where(e => e.Name == name && e.CategoryId == categoryId)
             .AnyAsync(ct);
 
     /// <inheritdoc/>
-    public async Task<bool> IsDuplicated(int id, string name, CancellationToken ct = default) =>
+    public async Task<bool> IsDuplicated(int id, string name, int categoryId, CancellationToken ct = default) =>
         await dbContext.Tags
-            .Where(e => e.Id != id && e.Name == name)
+            .Where(e => e.Id != id && e.Name == name && e.CategoryId == categoryId)
             .AnyAsync(ct);
 }

--- a/src/Infrastructure/Persistence/Repositories/Tags/TagRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Tags/TagRepository.cs
@@ -1,11 +1,11 @@
-﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories.Tags;
 
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
-using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Initiatives;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
+using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Tags;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -23,24 +23,13 @@ public class TagRepository : Repository<Tag, int>, ITagRepository
     {
     }
 
-    /// <summary>
-    /// Get if elements exists by name.
-    /// </summary>
-    /// <param name="name">Entity name.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>True if any element exists. False otherwise.</returns>
+    /// <inheritdoc/>
     public async Task<bool> AnyByName(string name, CancellationToken ct = default) =>
         await dbContext.Tags
             .Where(e => e.Name == name)
             .AnyAsync(ct);
 
-    /// <summary>
-    /// Get if element is duplicated.
-    /// </summary>
-    /// <param name="id">Entity identifier.</param>
-    /// <param name="name">Entity name.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>True if any element exists. False otherwise.</returns>
+    /// <inheritdoc/>
     public async Task<bool> IsDuplicated(int id, string name, CancellationToken ct = default) =>
         await dbContext.Tags
             .Where(e => e.Id != id && e.Name == name)

--- a/src/WebApi/Config/DependencyRegistry/ConfigAppServices.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigAppServices.cs
@@ -4,11 +4,13 @@ using IAVH.BioTablero.CM.Application.Interfaces.Services.Geo;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Logging;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Statistics;
+using IAVH.BioTablero.CM.Application.Interfaces.Services.Tags;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.TerritoryStory;
 using IAVH.BioTablero.CM.Application.Services.Geo;
 using IAVH.BioTablero.CM.Application.Services.Initiatives;
 using IAVH.BioTablero.CM.Application.Services.Logging;
 using IAVH.BioTablero.CM.Application.Services.Statistics;
+using IAVH.BioTablero.CM.Application.Services.Tag;
 using IAVH.BioTablero.CM.Application.Services.TerritoryStory;
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/WebApi/Config/DependencyRegistry/ConfigExternalServices.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigExternalServices.cs
@@ -5,6 +5,7 @@ using IAVH.BioTablero.CM.Application.Interfaces.ExternalServices;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Initiatives;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Locations;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Logging;
+using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Tags;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories.TerritoryStories;
 using IAVH.BioTablero.CM.Infrastructure.Integrations.Email;
 using IAVH.BioTablero.CM.Infrastructure.Integrations.Iam;
@@ -17,6 +18,7 @@ using IAVH.BioTablero.CM.Infrastructure.Integrations.Video;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories.Initiatives;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories.Locations;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories.Logging;
+using IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories.Tags;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories.TerritoryStories;
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/WebApi/Config/DependencyRegistry/ConfigMappings.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigMappings.cs
@@ -3,15 +3,18 @@
 using IAVH.BioTablero.CM.Application.DTOs.Geo;
 using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
 using IAVH.BioTablero.CM.Application.DTOs.Logging;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.DTOs.TerritoryStories;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
 using IAVH.BioTablero.CM.Application.Mappings.Geo;
 using IAVH.BioTablero.CM.Application.Mappings.Initiatives;
 using IAVH.BioTablero.CM.Application.Mappings.Logging;
+using IAVH.BioTablero.CM.Application.Mappings.Tags;
 using IAVH.BioTablero.CM.Application.Mappings.TerritoryStory;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Geo;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Logging;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 using IAVH.BioTablero.CM.Core.Domain.Entities.TerritoryStories;
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/WebApi/Config/DependencyRegistry/ConfigValidators.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigValidators.cs
@@ -3,6 +3,7 @@
 using FluentValidation;
 
 using IAVH.BioTablero.CM.Application.Validators.Initiatives;
+using IAVH.BioTablero.CM.Application.Validators.Tags;
 using IAVH.BioTablero.CM.Application.Validators.TerritoryStory;
 
 using Microsoft.Extensions.DependencyInjection;

--- a/src/WebApi/Config/DocsSetup/Examples/Tag/TagAddRequestExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Tag/TagAddRequestExample.cs
@@ -5,7 +5,7 @@ using IAVH.BioTablero.CM.Application.DTOs.Utils;
 
 using Swashbuckle.AspNetCore.Filters;
 
-using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums;
+using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums;
 
 /// <summary>
 /// Tag add request example.

--- a/src/WebApi/Config/DocsSetup/Examples/Tag/TagAddRequestExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Tag/TagAddRequestExample.cs
@@ -1,6 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Tag;
 
-using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.DTOs.Utils;
 
 using Swashbuckle.AspNetCore.Filters;

--- a/src/WebApi/Config/DocsSetup/Examples/Tag/TagEditRequestExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Tag/TagEditRequestExample.cs
@@ -1,0 +1,21 @@
+﻿namespace IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Tag;
+
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
+
+using Swashbuckle.AspNetCore.Filters;
+
+/// <summary>
+/// Tag edit request example.
+/// </summary>
+public class TagEditRequestExample : IExamplesProvider<TagDto>
+{
+    /// <summary>
+    /// Get examples for entity.
+    /// </summary>
+    /// <returns>Entity examples.</returns>
+    public TagDto GetExamples() => new()
+    {
+        Name = "Tag example",
+        Url = "https://example.com/tag-data",
+    };
+}

--- a/src/WebApi/Config/DocsSetup/Examples/Tag/TagOdataResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Tag/TagOdataResponseExample.cs
@@ -3,7 +3,7 @@
 using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
 using IAVH.BioTablero.CM.Application.DTOs.Utils;
 
-using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums;
+using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums;
 
 /// <summary>
 /// Tag OData response example.

--- a/src/WebApi/Config/DocsSetup/Examples/Tag/TagOdataResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Tag/TagOdataResponseExample.cs
@@ -1,6 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Tag;
 
-using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.DTOs.Utils;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums;

--- a/src/WebApi/Config/DocsSetup/Examples/Tag/TagResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Tag/TagResponseExample.cs
@@ -5,7 +5,7 @@ using IAVH.BioTablero.CM.Application.DTOs.Utils;
 
 using Swashbuckle.AspNetCore.Filters;
 
-using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums;
+using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums;
 
 /// <summary>
 /// Tag response example.

--- a/src/WebApi/Config/DocsSetup/Examples/Tag/TagResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Tag/TagResponseExample.cs
@@ -1,6 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Tag;
 
-using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
 using IAVH.BioTablero.CM.Application.DTOs.Utils;
 
 using Swashbuckle.AspNetCore.Filters;

--- a/src/WebApi/Controllers/Rest/Initiatives/TagCategoryController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/TagCategoryController.cs
@@ -6,10 +6,10 @@ using IAVH.BioTablero.CM.WebApi.Interfaces;
 
 using Microsoft.AspNetCore.Mvc;
 
-using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums;
+using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.TagEnums;
 
 /// <summary>
-/// Initiative Tag Category controller.
+/// Tag Category controller.
 /// </summary>
 /// <param name="webTools">General web tools.</param>
 /// <param name="entityService">Entity service.</param>

--- a/src/WebApi/Controllers/Rest/Tags/TagCategoryController.cs
+++ b/src/WebApi/Controllers/Rest/Tags/TagCategoryController.cs
@@ -1,4 +1,4 @@
-﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Rest.Initiatives;
+﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Rest.Tags;
 
 using IAVH.BioTablero.CM.Application.Interfaces.General;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;

--- a/src/WebApi/Controllers/Rest/Tags/TagController.cs
+++ b/src/WebApi/Controllers/Rest/Tags/TagController.cs
@@ -1,11 +1,11 @@
-﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Rest.Initiatives;
+﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Rest.Tags;
 
 using System.Threading;
 using System.Threading.Tasks;
 
-using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
-using IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
-using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Tags;
+using IAVH.BioTablero.CM.Application.Interfaces.Services.Tags;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 using IAVH.BioTablero.CM.Core.Domain.Utils.Constants;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Tag;

--- a/src/WebApi/Controllers/Rest/Tags/TagController.cs
+++ b/src/WebApi/Controllers/Rest/Tags/TagController.cs
@@ -87,7 +87,7 @@ public class TagController(
     [HttpPost("{id}")]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
-    [SwaggerRequestExample(typeof(TagDto), typeof(TagResponseExample))]
+    [SwaggerRequestExample(typeof(TagDto), typeof(TagEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TagResponseExample))]
     public async Task<IActionResult> Post(int id, [FromBody] TagDto requestData, CancellationToken ct)
     {


### PR DESCRIPTION
## 🛠️ Cambios
- Agregadas entidades de recursos configuradas, con datos por defecto y con su respectiva migración
- Correcciones en restricciones en etiquetas. Antes el nombre de una etiqueta era única. Ahora será único el conjunto del nombre y la categoría de esa etiqueta
- Añadida restricción en la entidad `initiative_tag` para evitar duplicidad de registros con el conjunto de columnas `initiative_id` y `tag_id`

## 📝 Tareas asociadas
Resuelve lib-420

## 🤔 Consideraciones
- No mezclar este PR hasta que #21 esté aprobado y terminado
- Es necesario actualizar las migraciones para aplicar algunos cambios
- Luego de aplicar la migración, es necesario ejecutar los scripts `3.tags.sql` y `4.resources.sql`. Puede encontrarlos en un comentario del ticket lib-420

## ✅ Verificaciones
- No aplica.