### PR TITLE
Fix Http methods in request for add an edit

### DIFF
--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeContactController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeContactController.cs
@@ -61,12 +61,12 @@ public class InitiativeContactController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(InitiativeContactDto), typeof(InitiativeContactAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeContactResponseExample))]
-    public async Task<IActionResult> Put([FromBody] InitiativeContactDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] InitiativeContactDto requestData, CancellationToken ct)
     {
         var response = await entityService.AddAsync(requestData, ct);
         return webTools.CustomResponse(response);
@@ -79,12 +79,12 @@ public class InitiativeContactController(
     /// <param name="requestData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(InitiativeContactDto), typeof(InitiativeContactEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeContactResponseExample))]
-    public async Task<IActionResult> Post(int id, [FromBody] InitiativeContactDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, [FromBody] InitiativeContactDto requestData, CancellationToken ct)
     {
         var response = await entityService.UpdateAsync(id, requestData, ct);
         return webTools.CustomResponse(response);

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeController.cs
@@ -95,12 +95,12 @@ public class InitiativeController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(InitiativeDto), typeof(InitiativeAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeResponseExample))]
-    public async Task<IActionResult> Put([FromBody] InitiativeDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] InitiativeDto requestData, CancellationToken ct)
     {
         var response = await entityService.AddAsync(requestData, ct);
         return webTools.CustomResponse(response);
@@ -113,12 +113,12 @@ public class InitiativeController(
     /// <param name="requestData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(InitiativeDto), typeof(InitiativeEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeResponseExample))]
-    public async Task<IActionResult> Post(int id, [FromBody] InitiativeDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, [FromBody] InitiativeDto requestData, CancellationToken ct)
     {
         var response = await entityService.UpdateAsync(id, requestData, ct);
         return webTools.CustomResponse(response);
@@ -131,7 +131,7 @@ public class InitiativeController(
     /// <param name="request">Polygon request.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("Polygon/{id}")]
+    [HttpPut("Polygon/{id}")]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(string), typeof(InitiativePolygonEditRequestExample))]

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeLocationController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeLocationController.cs
@@ -61,12 +61,12 @@ public class InitiativeLocationController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(InitiativeLocationDto), typeof(InitiativeLocationAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeLocationResponseExample))]
-    public async Task<IActionResult> Put([FromBody] InitiativeLocationDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] InitiativeLocationDto requestData, CancellationToken ct)
     {
         var response = await entityService.AddAsync(requestData, ct);
         return webTools.CustomResponse(response);
@@ -79,12 +79,12 @@ public class InitiativeLocationController(
     /// <param name="requestData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(InitiativeLocationDto), typeof(InitiativeLocationEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeLocationResponseExample))]
-    public async Task<IActionResult> Post(int id, [FromBody] InitiativeLocationDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, [FromBody] InitiativeLocationDto requestData, CancellationToken ct)
     {
         var response = await entityService.UpdateAsync(id, requestData, ct);
         return webTools.CustomResponse(response);

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeTagController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeTagController.cs
@@ -32,12 +32,12 @@ public class InitiativeTagController(
     /// <param name="tagId">Tag identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(void), StatusCodes.Status500InternalServerError)]
-    public async Task<IActionResult> Put(int initiativeId, int tagId, CancellationToken ct)
+    public async Task<IActionResult> Post(int initiativeId, int tagId, CancellationToken ct)
     {
         var response = await entityService.AddAsync(initiativeId, tagId, ct);
         return webTools.CustomResponse(response);

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeUserController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeUserController.cs
@@ -62,12 +62,12 @@ public class InitiativeUserController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(InitiativeUserDto), typeof(InitiativeUserAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeUserResponseExample))]
-    public async Task<IActionResult> Put([FromBody] InitiativeUserDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] InitiativeUserDto requestData, CancellationToken ct)
     {
         var response = await entityService.AddAsync(requestData, ct);
         return webTools.CustomResponse(response);
@@ -80,12 +80,12 @@ public class InitiativeUserController(
     /// <param name="requestData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(InitiativeUserDto), typeof(InitiativeUserEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeUserResponseExample))]
-    public async Task<IActionResult> Post(int id, [FromBody] InitiativeUserDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, [FromBody] InitiativeUserDto requestData, CancellationToken ct)
     {
         var reviewerUserName = HttpContext.GetUserName();
         var response = await entityService.UpdateAsync(id, reviewerUserName, requestData, ct);

--- a/src/WebApi/Controllers/Rest/Initiatives/JoinInvitationController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/JoinInvitationController.cs
@@ -51,11 +51,11 @@ public class JoinInvitationController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [SwaggerRequestExample(typeof(JoinInvitationDto), typeof(JoinInvitationAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(JoinInvitationResponseExample))]
-    public async Task<IActionResult> Put([FromBody] JoinInvitationDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] JoinInvitationDto requestData, CancellationToken ct)
     {
         requestData.Creator = HttpContext.GetUserName();
         var response = await entityService.AddAsync(requestData, ct);

--- a/src/WebApi/Controllers/Rest/Initiatives/JoinRequestController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/JoinRequestController.cs
@@ -73,10 +73,10 @@ public class JoinRequestController(
     /// <param name="requestStatus">Join request status.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Authorize]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(JoinRequestResponseExample))]
-    public async Task<IActionResult> Post(int id, JoinRequestStatusEnum requestStatus, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, JoinRequestStatusEnum requestStatus, CancellationToken ct)
     {
         var requestData = new JoinRequestDto()
         {

--- a/src/WebApi/Controllers/Rest/Initiatives/JoinRequestController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/JoinRequestController.cs
@@ -54,12 +54,12 @@ public class JoinRequestController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [Authorize]
     [SwaggerRequestExample(typeof(JoinRequestDto), typeof(JoinRequestAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(JoinRequestResponseExample))]
-    public async Task<IActionResult> Put([FromBody] JoinRequestDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] JoinRequestDto requestData, CancellationToken ct)
     {
         requestData.UserName = HttpContext.GetUserName();
         var response = await entityService.AddAsync(requestData, ct);

--- a/src/WebApi/Controllers/Rest/Tags/TagController.cs
+++ b/src/WebApi/Controllers/Rest/Tags/TagController.cs
@@ -66,12 +66,12 @@ public class TagController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(TagDto), typeof(TagAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TagResponseExample))]
-    public async Task<IActionResult> Put([FromBody] TagDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] TagDto requestData, CancellationToken ct)
     {
         var response = await entityService.AddAsync(requestData, ct);
         return webTools.CustomResponse(response);
@@ -84,12 +84,12 @@ public class TagController(
     /// <param name="requestData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Consumes("application/json")]
     [Authorize(Roles = IamConstants.RoleModuleAdmin)]
     [SwaggerRequestExample(typeof(TagDto), typeof(TagEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TagResponseExample))]
-    public async Task<IActionResult> Post(int id, [FromBody] TagDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, [FromBody] TagDto requestData, CancellationToken ct)
     {
         var response = await entityService.UpdateAsync(id, requestData, ct);
         return webTools.CustomResponse(response);

--- a/src/WebApi/Controllers/Rest/TerritoryStories/TerritoryStoryController.cs
+++ b/src/WebApi/Controllers/Rest/TerritoryStories/TerritoryStoryController.cs
@@ -67,12 +67,12 @@ public class TerritoryStoryController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [Authorize]
     [SwaggerRequestExample(typeof(TerritoryStoryDto), typeof(TerritoryStoryAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TerritoryStoryResponseExample))]
-    public async Task<IActionResult> Put([FromBody] TerritoryStoryDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] TerritoryStoryDto requestData, CancellationToken ct)
     {
         requestData.AuthorUserName = HttpContext.GetUserName();
         var response = await entityService.AddAsync(requestData, ct);
@@ -86,12 +86,12 @@ public class TerritoryStoryController(
     /// <param name="requestData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Consumes("application/json")]
     [Authorize]
     [SwaggerRequestExample(typeof(TerritoryStoryDto), typeof(TerritoryStoryEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TerritoryStoryResponseExample))]
-    public async Task<IActionResult> Post(int id, [FromBody] TerritoryStoryDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, [FromBody] TerritoryStoryDto requestData, CancellationToken ct)
     {
         var response = await entityService.UpdateAsync(id, HttpContext.GetUserName(), requestData, ct);
         return webTools.CustomResponse(response);

--- a/src/WebApi/Controllers/Rest/TerritoryStories/TerritoryStoryImageController.cs
+++ b/src/WebApi/Controllers/Rest/TerritoryStories/TerritoryStoryImageController.cs
@@ -66,10 +66,10 @@ public class TerritoryStoryImageController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Authorize]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TerritoryStoryImageResponseExample))]
-    public async Task<IActionResult> Put([FromForm] TerritoryStoryImageAddRequest requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromForm] TerritoryStoryImageAddRequest requestData, CancellationToken ct)
     {
         var requestDataDto = new TerritoryStoryImageDto()
         {
@@ -88,10 +88,10 @@ public class TerritoryStoryImageController(
     /// <param name="requestData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Authorize]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TerritoryStoryImageResponseExample))]
-    public async Task<IActionResult> Post(int id, [FromForm] TerritoryStoryImageEditRequest requestData, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, [FromForm] TerritoryStoryImageEditRequest requestData, CancellationToken ct)
     {
         var requestDataDto = new TerritoryStoryImageDto()
         {

--- a/src/WebApi/Controllers/Rest/TerritoryStories/TerritoryStoryVideoController.cs
+++ b/src/WebApi/Controllers/Rest/TerritoryStories/TerritoryStoryVideoController.cs
@@ -64,12 +64,12 @@ public class TerritoryStoryVideoController(
     /// <param name="requestData">Request data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
-    [HttpPut]
+    [HttpPost]
     [Consumes("application/json")]
     [Authorize]
     [SwaggerRequestExample(typeof(TerritoryStoryVideoDto), typeof(TerritoryStoryVideoAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TerritoryStoryVideoResponseExample))]
-    public async Task<IActionResult> Put([FromBody] TerritoryStoryVideoDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Post([FromBody] TerritoryStoryVideoDto requestData, CancellationToken ct)
     {
         var response = await entityService.AddAsync(HttpContext.GetUserName(), requestData, ct);
         return webTools.CustomResponse(response);
@@ -82,12 +82,12 @@ public class TerritoryStoryVideoController(
     /// <param name="requestData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated entity data.</returns>
-    [HttpPost("{id}")]
+    [HttpPut("{id}")]
     [Consumes("application/json")]
     [Authorize]
     [SwaggerRequestExample(typeof(TerritoryStoryVideoDto), typeof(TerritoryStoryVideoEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(TerritoryStoryVideoResponseExample))]
-    public async Task<IActionResult> Post(int id, [FromBody] TerritoryStoryVideoDto requestData, CancellationToken ct)
+    public async Task<IActionResult> Put(int id, [FromBody] TerritoryStoryVideoDto requestData, CancellationToken ct)
     {
         var response = await entityService.UpdateAsync(id, HttpContext.GetUserName(), requestData, ct);
         return webTools.CustomResponse(response);


### PR DESCRIPTION
## 🛠️ Changes
This PR corrects the HTTP method usage to align with REST semantics.
Update endpoints have been changed from POST to PUT, and creation endpoints from PUT to POST.


## 📝 Associated issues
- Solves LIB-460

## 🤔 Considerations

## ✅ Checks

- HTTP methods align with REST semantics (POST=create, PUT=update)
- No business logic was modified
- Existing behavior remains unchanged

