### PR TITLE
Añadir endpoints para solicitudes de ingreso a iniciativas

### DIFF
--- a/src/Application/Interfaces/Services/Initiatives/IInitiativeUserService.cs
+++ b/src/Application/Interfaces/Services/Initiatives/IInitiativeUserService.cs
@@ -11,7 +11,7 @@ using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 /// <summary>
 /// Initiative User service interface.
 /// </summary>
-public interface IInitiativeUserService : IRead<InitiativeUser, int>, IAdd<InitiativeUserDto>, IDelete<int>
+public interface IInitiativeUserService : IRead<InitiativeUser, int>, IAdd<InitiativeUserDto>
 {
     /// <summary>
     /// Get entities by initiative.
@@ -26,8 +26,19 @@ public interface IInitiativeUserService : IRead<InitiativeUser, int>, IAdd<Initi
     /// </summary>
     /// <param name="id">Element identifier.</param>
     /// <param name="reviewerUserName">Reviewer user name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
     /// <param name="entityData">Entity data.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
-    Task<CustomWebResponse> UpdateAsync(int id, string reviewerUserName, InitiativeUserDto entityData, CancellationToken ct = default);
+    Task<CustomWebResponse> UpdateAsync(int id, string reviewerUserName, bool userIsAdmin, InitiativeUserDto entityData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete element.
+    /// </summary>
+    /// <param name="id">Element identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default);
 }

--- a/src/Application/Interfaces/Services/Initiatives/IJoinRequestService.cs
+++ b/src/Application/Interfaces/Services/Initiatives/IJoinRequestService.cs
@@ -28,7 +28,7 @@ public interface IJoinRequestService : IRead<JoinRequest, int>, IAdd<JoinRequest
     /// <summary>
     /// Get entities by user name.
     /// </summary>
-    /// <param name="userName">Initiative identifier.</param>
+    /// <param name="userName">User name.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     Task<CustomWebResponse> GetByUserNameAsync(string userName, CancellationToken ct = default);

--- a/src/Application/Interfaces/Services/Initiatives/IJoinRequestService.cs
+++ b/src/Application/Interfaces/Services/Initiatives/IJoinRequestService.cs
@@ -26,6 +26,23 @@ public interface IJoinRequestService : IRead<JoinRequest, int>, IAdd<JoinRequest
     Task<CustomWebResponse> GetListAsync(int initiativeId, string userName, ODataQueryOptions<JoinRequest> queryOptions, CancellationToken ct = default);
 
     /// <summary>
+    /// Get entities by user name.
+    /// </summary>
+    /// <param name="userName">Initiative identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> GetByUserNameAsync(string userName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Cancel element.
+    /// </summary>
+    /// <param name="id">Element identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> CancelAsync(int id, string userName, CancellationToken ct = default);
+
+    /// <summary>
     /// Send notifications for old pending join requests.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -212,7 +212,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
         // Validate number of leaders
         var leaders = await entityRepository.GetByInitiativeAndLevelAsync(id, entity.InitiativeId, (int)InitiativeUserLevelEnum.Leader, ct);
 
-        if (entity.LevelId == (int)InitiativeUserLevelEnum.Leader && entityData.Level.Id != (int)InitiativeUserLevelEnum.Leader && !leaders.Any())
+        if (entity.LevelId == (int)InitiativeUserLevelEnum.Leader && entityData.Level.Id != (int)InitiativeUserLevelEnum.Leader && leaders.Count() <= 1)
         {
             return new(true)
             {

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -170,7 +171,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> UpdateAsync(int id, string reviewerUserName, InitiativeUserDto entityData, CancellationToken ct = default)
+    public async Task<CustomWebResponse> UpdateAsync(int id, string reviewerUserName, bool userIsAdmin, InitiativeUserDto entityData, CancellationToken ct = default)
     {
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
@@ -192,6 +193,20 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await entityRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, reviewerUserName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Validate number of leaders
@@ -234,7 +249,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> DeleteAsync(int id, CancellationToken ct = default)
+    public async Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
     {
         // Validate entity
         var entity = await entityRepository.GetByIdAsync(id, ct);
@@ -245,6 +260,20 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await entityRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Validate number of leaders

--- a/src/Application/Services/Initiatives/JoinRequestService.cs
+++ b/src/Application/Services/Initiatives/JoinRequestService.cs
@@ -107,6 +107,20 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int>,
     }
 
     /// <inheritdoc/>
+    public async Task<CustomWebResponse> GetByUserNameAsync(string userName, CancellationToken ct = default)
+    {
+        var dataListEntity = await entityRepository.GetByUserNameAsync(userName, ct);
+
+        var dataListDto = dataListEntity
+            .Select(mapper.Map);
+
+        return new()
+        {
+            ResponseBody = dataListDto,
+        };
+    }
+
+    /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(JoinRequestDto entityData, CancellationToken ct = default)
     {
         // Validate data
@@ -270,6 +284,39 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int>,
         {
             ResponseBody = entityData,
         };
+    }
+
+    /// <inheritdoc/>
+    public async Task<CustomWebResponse> CancelAsync(int id, string userName, CancellationToken ct = default)
+    {
+        // Validate entity
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
+        }
+
+        // Validate user
+        if (entity.UserName != userName || entity.StatusId != (int)JoinRequestStatusEnum.UnderReview)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        entity.StatusId = (int)JoinRequestStatusEnum.Cancelled;
+        await entityRepository.UpdateAsync(entity, ct);
+
+        var entityData = mapper.Map(entity);
+
+        logger.AddLog(LogType.Delete, "Cancelled JoinRequest", "{@EntityData}", entityData);
+
+        return new();
     }
 
     /// <inheritdoc/>

--- a/src/Core/Domain/Utils/Enums/InitiativesEnums.cs
+++ b/src/Core/Domain/Utils/Enums/InitiativesEnums.cs
@@ -61,5 +61,10 @@ public static class InitiativesEnums
         /// Rejected status.
         /// </summary>
         Rejected,
+
+        /// <summary>
+        /// Cancelled status.
+        /// </summary>
+        Cancelled,
     }
 }

--- a/src/Core/Interfaces/Repositories/Initiatives/IJoinRequestRepository.cs
+++ b/src/Core/Interfaces/Repositories/Initiatives/IJoinRequestRepository.cs
@@ -13,6 +13,14 @@ using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 public interface IJoinRequestRepository : IRepository<JoinRequest, int>
 {
     /// <summary>
+    /// Get elements by user name.
+    /// </summary>
+    /// <param name="userName">User name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Elements list.</returns>
+    Task<IEnumerable<JoinRequest>> GetByUserNameAsync(string userName, CancellationToken ct = default);
+
+    /// <summary>
     /// Add initiative filter.
     /// </summary>
     /// <param name="initiativeId">Initiative identifier.</param>

--- a/src/Infrastructure/Persistence/Migrations/20260218185849_UpdateInitiativeJoinRequestStatuses.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260218185849_UpdateInitiativeJoinRequestStatuses.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20260218185849_UpdateInitiativeJoinRequestStatuses")]
+    partial class UpdateInitiativeJoinRequestStatuses
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260218185849_UpdateInitiativeJoinRequestStatuses.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260218185849_UpdateInitiativeJoinRequestStatuses.cs
@@ -1,0 +1,23 @@
+﻿#nullable disable
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class UpdateInitiativeJoinRequestStatuses : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder) => migrationBuilder.InsertData(
+            schema: "initiatives",
+            table: "join_request_status",
+            columns: new[] { "id", "name" },
+            values: new object[] { 4, "Cancelled" });
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder) => migrationBuilder.DeleteData(
+            schema: "initiatives",
+            table: "join_request_status",
+            keyColumn: "id",
+            keyValue: 4);
+}

--- a/src/Infrastructure/Persistence/Repositories/Initiatives/JoinRequestRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Initiatives/JoinRequestRepository.cs
@@ -34,6 +34,13 @@ public class JoinRequestRepository : Repository<JoinRequest, int>, IJoinRequestR
     }
 
     /// <inheritdoc/>
+    public async Task<IEnumerable<JoinRequest>> GetByUserNameAsync(string userName, CancellationToken ct = default) =>
+        await dbContext.JoinRequests
+            .Include(e => e.Initiative)
+            .Where(e => e.UserName == userName)
+            .ToListAsync(ct);
+
+    /// <inheritdoc/>
     public IQueryable<JoinRequest> AddInitiativeFilter(int initiativeId, IQueryable<JoinRequest> query) =>
         query
             .Where(e => e.InitiativeId == initiativeId);

--- a/src/WebApi/Config/DocsSetup/Examples/JoinRequest/JoinRequestListResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/JoinRequest/JoinRequestListResponseExample.cs
@@ -1,0 +1,32 @@
+﻿namespace IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.JoinRequest;
+
+using System;
+using System.Collections.Generic;
+
+using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+using IAVH.BioTablero.CM.Application.DTOs.Utils;
+
+using Swashbuckle.AspNetCore.Filters;
+
+using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums;
+
+/// <summary>
+/// Join Request list response example.
+/// </summary>
+public class JoinRequestListResponseExample : IExamplesProvider<List<JoinRequestDto>>
+{
+    /// <inheritdoc/>
+    public List<JoinRequestDto> GetExamples() =>
+    [
+        new()
+        {
+            Id = 0,
+            InitiativeId = 0,
+            UserName = "Example",
+            ReviewerUserName = "ReviewerExample",
+            CreationDate = DateTime.Now,
+            ResponseDate = DateTime.Now,
+            Status = new EnumEntityDto<JoinRequestStatus>(JoinRequestStatus.Rejected),
+        }
+    ];
+}

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeUserController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeUserController.cs
@@ -1,5 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Rest.Initiatives;
 
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -82,13 +83,14 @@ public class InitiativeUserController(
     /// <returns>Updated entity data.</returns>
     [HttpPut("{id}")]
     [Consumes("application/json")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     [SwaggerRequestExample(typeof(InitiativeUserDto), typeof(InitiativeUserEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeUserResponseExample))]
     public async Task<IActionResult> Put(int id, [FromBody] InitiativeUserDto requestData, CancellationToken ct)
     {
         var reviewerUserName = HttpContext.GetUserName();
-        var response = await entityService.UpdateAsync(id, reviewerUserName, requestData, ct);
+        var userIsAdmin = HttpContext.GetRoles().Contains(IamConstants.RoleModuleAdmin);
+        var response = await entityService.UpdateAsync(id, reviewerUserName, userIsAdmin, requestData, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -99,10 +101,11 @@ public class InitiativeUserController(
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     [HttpDelete("{id}")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     public async Task<IActionResult> Delete(int id, CancellationToken ct)
     {
-        var response = await entityService.DeleteAsync(id, ct);
+        var userIsAdmin = HttpContext.GetRoles().Contains(IamConstants.RoleModuleAdmin);
+        var response = await entityService.DeleteAsync(id, HttpContext.GetUserName(), userIsAdmin, ct);
         return webTools.CustomResponse(response);
     }
 }

--- a/src/WebApi/Controllers/Rest/Initiatives/JoinRequestController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/JoinRequestController.cs
@@ -52,7 +52,7 @@ public class JoinRequestController(
     /// Get my join requests.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Selected entity data.</returns>
+    /// <returns>Join Requests list.</returns>
     [Authorize]
     [HttpGet("MyRequests")]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(JoinRequestListResponseExample))]

--- a/src/WebApi/Controllers/Rest/Initiatives/JoinRequestController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/JoinRequestController.cs
@@ -49,6 +49,20 @@ public class JoinRequestController(
     }
 
     /// <summary>
+    /// Get my join requests.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Selected entity data.</returns>
+    [Authorize]
+    [HttpGet("MyRequests")]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(JoinRequestListResponseExample))]
+    public async Task<IActionResult> GetListInitiativesData(CancellationToken ct)
+    {
+        var response = await entityService.GetByUserNameAsync(HttpContext.GetUserName(), ct);
+        return webTools.CustomResponse(response);
+    }
+
+    /// <summary>
     /// Add entity.
     /// </summary>
     /// <param name="requestData">Request data.</param>
@@ -85,6 +99,20 @@ public class JoinRequestController(
         };
 
         var response = await entityService.UpdateAsync(id, requestData, ct);
+        return webTools.CustomResponse(response);
+    }
+
+    /// <summary>
+    /// Cancel request.
+    /// </summary>
+    /// <param name="id">Entity identifier.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    [HttpDelete("Cancel/{id}")]
+    [Authorize]
+    public async Task<IActionResult> Cancel(int id, CancellationToken ct)
+    {
+        var response = await entityService.CancelAsync(id, HttpContext.GetUserName(), ct);
         return webTools.CustomResponse(response);
     }
 }


### PR DESCRIPTION
## 🛠️ Cambios
- Agregados endpoints para poder ver y cancelar mis solicitudes
- **Ñapa:** Solucionados problemas con endpoints de usuarios de iniciativa. Ahora los endpoints para editar o eliminar están activos para los líderes. Antes solo funcionaban para administradores

## 📝 Tareas asociadas
Resuelve lib-493

## 🤔 Consideraciones
- No mezclar hasta que #29 esté aprobado y cerrado
- Es necesario aplicar las migraciones o recrear la base de datos para que el desarrollo funcione correctamente

## ✅ Verificaciones
- No aplica.