### PR TITLE
Correcciones en modificación de iniciativas

### DIFF
--- a/src/Application/Interfaces/Services/Initiatives/IInitiativeContactService.cs
+++ b/src/Application/Interfaces/Services/Initiatives/IInitiativeContactService.cs
@@ -11,7 +11,7 @@ using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 /// <summary>
 /// Initiative Contact service interface.
 /// </summary>
-public interface IInitiativeContactService : IRead<InitiativeContact, int>, IAdd<InitiativeContactDto>, IUpdate<InitiativeContactDto, int>, IDelete<int>
+public interface IInitiativeContactService : IRead<InitiativeContact, int>
 {
     /// <summary>
     /// Get entities by initiative.
@@ -20,4 +20,35 @@ public interface IInitiativeContactService : IRead<InitiativeContact, int>, IAdd
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     Task<CustomWebResponse> GetByInitiativeAsync(int initiativeId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Add element.
+    /// </summary>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="entityData">Entity data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, InitiativeContactDto entityData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Update element.
+    /// </summary>
+    /// <param name="id">Element identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="entityData">Entity data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeContactDto entityData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete element.
+    /// </summary>
+    /// <param name="id">Element identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default);
 }

--- a/src/Application/Interfaces/Services/Initiatives/IInitiativeLocationService.cs
+++ b/src/Application/Interfaces/Services/Initiatives/IInitiativeLocationService.cs
@@ -11,7 +11,7 @@ using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 /// <summary>
 /// Initiative Location service interface.
 /// </summary>
-public interface IInitiativeLocationService : IRead<InitiativeLocation, int>, IAdd<InitiativeLocationDto>, IUpdate<InitiativeLocationDto, int>, IDelete<int>
+public interface IInitiativeLocationService : IRead<InitiativeLocation, int>
 {
     /// <summary>
     /// Get entities by initiative.
@@ -20,4 +20,35 @@ public interface IInitiativeLocationService : IRead<InitiativeLocation, int>, IA
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     Task<CustomWebResponse> GetByInitiativeAsync(int initiativeId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Add element.
+    /// </summary>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="entityData">Entity data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, InitiativeLocationDto entityData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Update element.
+    /// </summary>
+    /// <param name="id">Element identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="entityData">Entity data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeLocationDto entityData, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete element.
+    /// </summary>
+    /// <param name="id">Element identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default);
 }

--- a/src/Application/Interfaces/Services/Initiatives/IInitiativeService.cs
+++ b/src/Application/Interfaces/Services/Initiatives/IInitiativeService.cs
@@ -14,7 +14,7 @@ using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums;
 /// <summary>
 /// Initiative service interface.
 /// </summary>
-public interface IInitiativeService : IRead<Initiative, int>, IAdd<InitiativeDto>, IUpdate<InitiativeDto, int>, IDisable<int>
+public interface IInitiativeService : IRead<Initiative, int>, IAdd<InitiativeDto>, IDisable<int>
 {
     /// <summary>
     /// Get entities by user name.
@@ -23,6 +23,17 @@ public interface IInitiativeService : IRead<Initiative, int>, IAdd<InitiativeDto
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     Task<CustomWebResponse> GetByUserNameAsync(string userName, CancellationToken ct = default);
+
+    /// <summary>
+    /// Update element.
+    /// </summary>
+    /// <param name="id">Element identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="entityData">Entity data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeDto entityData, CancellationToken ct = default);
 
     /// <summary>
     /// Upload image.

--- a/src/Application/Interfaces/Services/Initiatives/IInitiativeTagService.cs
+++ b/src/Application/Interfaces/Services/Initiatives/IInitiativeTagService.cs
@@ -4,19 +4,30 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using IAVH.BioTablero.CM.Application.Domain;
-using IAVH.BioTablero.CM.Application.Interfaces.General;
 
 /// <summary>
 /// Initiative Tag service interface.
 /// </summary>
-public interface IInitiativeTagService : IDelete<int>
+public interface IInitiativeTagService
 {
     /// <summary>
     /// Add element.
     /// </summary>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
     /// <param name="initiativeId">Initiative identifier.</param>
     /// <param name="tagId">Tag identifier.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
-    Task<CustomWebResponse> AddAsync(int initiativeId, int tagId, CancellationToken ct = default);
+    Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, int initiativeId, int tagId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Delete element.
+    /// </summary>
+    /// <param name="id">Element identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default);
 }

--- a/src/Application/Services/Initiatives/InitiativeContactService.cs
+++ b/src/Application/Services/Initiatives/InitiativeContactService.cs
@@ -22,8 +22,6 @@ using Serilog;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.LogEnums;
 
-using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
-
 /// <summary>
 /// Initiative Contact service.
 /// </summary>
@@ -33,7 +31,6 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     private readonly IValidator<InitiativeContactDto> entityValidator;
     private readonly ILogger logger;
     private new readonly IMapperCreateReadAndUpdate<InitiativeContact, InitiativeContactDto> mapper;
-    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly IInitiativeRepository initiativeRepository;
 
     /// <summary>
@@ -44,7 +41,6 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="entityValidator">Entity validator.</param>
     /// <param name="logger">System logger.</param>
-    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="initiativeRepository">Initiative repository.</param>
     public InitiativeContactService(
         IInitiativeContactRepository entityRepository,
@@ -52,7 +48,6 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
         IValidationErrorTranslator errorTranslator,
         IValidator<InitiativeContactDto> entityValidator,
         ILogger logger,
-        IInitiativeUserRepository initiativeUserRepository,
         IInitiativeRepository initiativeRepository)
         : base(entityRepository, mapper, errorTranslator)
     {
@@ -60,7 +55,6 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
         this.mapper = mapper;
         this.entityValidator = entityValidator;
         this.logger = logger;
-        this.initiativeUserRepository = initiativeUserRepository;
         this.initiativeRepository = initiativeRepository;
     }
 
@@ -86,7 +80,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
 
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {
@@ -155,7 +149,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
 
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {
@@ -221,7 +215,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
 
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {

--- a/src/Application/Services/Initiatives/InitiativeContactService.cs
+++ b/src/Application/Services/Initiatives/InitiativeContactService.cs
@@ -78,17 +78,12 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
         // Validate user permissions
         var initiativeId = entityData.InitiativeId ?? 0;
 
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate data
@@ -147,17 +142,12 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var initiativeId = entity?.InitiativeId ?? 0;
 
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate entity
@@ -213,17 +203,12 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var initiativeId = entity?.InitiativeId ?? 0;
 
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate entity

--- a/src/Application/Services/Initiatives/InitiativeContactService.cs
+++ b/src/Application/Services/Initiatives/InitiativeContactService.cs
@@ -30,10 +30,10 @@ using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.Initi
 public class InitiativeContactService : ServiceRead<InitiativeContact, InitiativeContactDto, int>, IInitiativeContactService
 {
     private new readonly IInitiativeContactRepository entityRepository;
-    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly IValidator<InitiativeContactDto> entityValidator;
     private readonly ILogger logger;
     private new readonly IMapperCreateReadAndUpdate<InitiativeContact, InitiativeContactDto> mapper;
+    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly IInitiativeRepository initiativeRepository;
 
     /// <summary>
@@ -43,16 +43,16 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     /// <param name="mapper">Entity mapper.</param>
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="entityValidator">Entity validator.</param>
-    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="logger">System logger.</param>
+    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="initiativeRepository">Initiative repository.</param>
     public InitiativeContactService(
         IInitiativeContactRepository entityRepository,
         IMapperCreateReadAndUpdate<InitiativeContact, InitiativeContactDto> mapper,
         IValidationErrorTranslator errorTranslator,
         IValidator<InitiativeContactDto> entityValidator,
-        IInitiativeUserRepository initiativeUserRepository,
         ILogger logger,
+        IInitiativeUserRepository initiativeUserRepository,
         IInitiativeRepository initiativeRepository)
         : base(entityRepository, mapper, errorTranslator)
     {

--- a/src/Application/Services/Initiatives/InitiativeContactService.cs
+++ b/src/Application/Services/Initiatives/InitiativeContactService.cs
@@ -81,6 +81,22 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, InitiativeContactDto entityData, CancellationToken ct = default)
     {
+        // Validate user permissions
+        var initiativeId = entityData.InitiativeId ?? 0;
+
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
 
@@ -93,7 +109,6 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
         }
 
         // Validate initiative
-        var initiativeId = entityData.InitiativeId ?? 0;
         var initiativeExists = await initiativeRepository.AnyAsync(initiativeId, ct);
 
         if (!initiativeExists)
@@ -102,20 +117,6 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Initiatives.NotFound),
             };
-        }
-
-        // Validate user permissions
-        if (!userIsAdmin)
-        {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-            if (!authorizedUserAction)
-            {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
         }
 
         // Validate duplicated entities
@@ -148,6 +149,32 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeContactDto entityData, CancellationToken ct = default)
     {
+        // Validate user permissions
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var initiativeId = entity?.InitiativeId ?? 0;
+
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
@@ -157,31 +184,6 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
             {
                 ResponseBody = errorTranslator.Translate(validationResult.Errors),
             };
-        }
-
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user permissions
-        if (!userIsAdmin)
-        {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-            if (!authorizedUserAction)
-            {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
         }
 
         // Validate duplicated entities
@@ -213,21 +215,13 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
     {
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
         // Validate user permissions
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var initiativeId = entity?.InitiativeId ?? 0;
+
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
 
             if (!authorizedUserAction)
             {
@@ -236,6 +230,15 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
                     StatusCode = HttpStatusCode.Forbidden,
                 };
             }
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
         }
 
         await entityRepository.DeleteAsync(entity, ct);

--- a/src/Application/Services/Initiatives/InitiativeContactService.cs
+++ b/src/Application/Services/Initiatives/InitiativeContactService.cs
@@ -1,6 +1,7 @@
 ﻿namespace IAVH.BioTablero.CM.Application.Services.Initiatives;
 
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,12 +22,15 @@ using Serilog;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.LogEnums;
 
+using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
+
 /// <summary>
 /// Initiative Contact service.
 /// </summary>
 public class InitiativeContactService : ServiceRead<InitiativeContact, InitiativeContactDto, int>, IInitiativeContactService
 {
     private new readonly IInitiativeContactRepository entityRepository;
+    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly IValidator<InitiativeContactDto> entityValidator;
     private readonly ILogger logger;
     private new readonly IMapperCreateReadAndUpdate<InitiativeContact, InitiativeContactDto> mapper;
@@ -39,6 +43,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     /// <param name="mapper">Entity mapper.</param>
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="entityValidator">Entity validator.</param>
+    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="logger">System logger.</param>
     /// <param name="initiativeRepository">Initiative repository.</param>
     public InitiativeContactService(
@@ -46,6 +51,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
         IMapperCreateReadAndUpdate<InitiativeContact, InitiativeContactDto> mapper,
         IValidationErrorTranslator errorTranslator,
         IValidator<InitiativeContactDto> entityValidator,
+        IInitiativeUserRepository initiativeUserRepository,
         ILogger logger,
         IInitiativeRepository initiativeRepository)
         : base(entityRepository, mapper, errorTranslator)
@@ -54,6 +60,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
         this.mapper = mapper;
         this.entityValidator = entityValidator;
         this.logger = logger;
+        this.initiativeUserRepository = initiativeUserRepository;
         this.initiativeRepository = initiativeRepository;
     }
 
@@ -72,7 +79,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> AddAsync(InitiativeContactDto entityData, CancellationToken ct = default)
+    public async Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, InitiativeContactDto entityData, CancellationToken ct = default)
     {
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
@@ -95,6 +102,20 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Initiatives.NotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Validate duplicated entities
@@ -125,7 +146,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> UpdateAsync(int id, InitiativeContactDto entityData, CancellationToken ct = default)
+    public async Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeContactDto entityData, CancellationToken ct = default)
     {
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
@@ -147,6 +168,20 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Validate duplicated entities
@@ -176,7 +211,7 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> DeleteAsync(int id, CancellationToken ct = default)
+    public async Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
     {
         // Validate entity
         var entity = await entityRepository.GetByIdAsync(id, ct);
@@ -187,6 +222,20 @@ public class InitiativeContactService : ServiceRead<InitiativeContact, Initiativ
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         await entityRepository.DeleteAsync(entity, ct);

--- a/src/Application/Services/Initiatives/InitiativeLocationService.cs
+++ b/src/Application/Services/Initiatives/InitiativeLocationService.cs
@@ -1,6 +1,7 @@
 ﻿namespace IAVH.BioTablero.CM.Application.Services.Initiatives;
 
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,6 +23,8 @@ using Serilog;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.LogEnums;
 
+using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
+
 /// <summary>
 /// Initiative Location service.
 /// </summary>
@@ -31,6 +34,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     private readonly IValidator<InitiativeLocationDto> entityValidator;
     private readonly ILogger logger;
     private new readonly IMapperCreateReadAndUpdate<InitiativeLocation, InitiativeLocationDto> mapper;
+    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly ILocationRepository locationRepository;
     private readonly IInitiativeRepository initiativeRepository;
 
@@ -42,6 +46,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="entityValidator">Entity validator.</param>
     /// <param name="logger">System logger.</param>
+    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="locationRepository">Location repository.</param>
     /// <param name="initiativeRepository">Initiative repository.</param>
     public InitiativeLocationService(
@@ -50,6 +55,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         IValidationErrorTranslator errorTranslator,
         IValidator<InitiativeLocationDto> entityValidator,
         ILogger logger,
+        IInitiativeUserRepository initiativeUserRepository,
         ILocationRepository locationRepository,
         IInitiativeRepository initiativeRepository)
         : base(entityRepository, mapper, errorTranslator)
@@ -58,6 +64,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         this.mapper = mapper;
         this.entityValidator = entityValidator;
         this.logger = logger;
+        this.initiativeUserRepository = initiativeUserRepository;
         this.locationRepository = locationRepository;
         this.initiativeRepository = initiativeRepository;
     }
@@ -77,7 +84,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> AddAsync(InitiativeLocationDto entityData, CancellationToken ct = default)
+    public async Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, InitiativeLocationDto entityData, CancellationToken ct = default)
     {
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
@@ -100,6 +107,20 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Initiatives.NotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Validate location
@@ -152,7 +173,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> UpdateAsync(int id, InitiativeLocationDto entityData, CancellationToken ct = default)
+    public async Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeLocationDto entityData, CancellationToken ct = default)
     {
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
@@ -174,6 +195,20 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Validate location
@@ -224,7 +259,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> DeleteAsync(int id, CancellationToken ct = default)
+    public async Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
     {
         // Validate entity
         var entity = await entityRepository.GetByIdAsync(id, ct);
@@ -235,6 +270,20 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Validate number of locations

--- a/src/Application/Services/Initiatives/InitiativeLocationService.cs
+++ b/src/Application/Services/Initiatives/InitiativeLocationService.cs
@@ -23,8 +23,6 @@ using Serilog;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.LogEnums;
 
-using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
-
 /// <summary>
 /// Initiative Location service.
 /// </summary>
@@ -34,7 +32,6 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     private readonly IValidator<InitiativeLocationDto> entityValidator;
     private readonly ILogger logger;
     private new readonly IMapperCreateReadAndUpdate<InitiativeLocation, InitiativeLocationDto> mapper;
-    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly ILocationRepository locationRepository;
     private readonly IInitiativeRepository initiativeRepository;
 
@@ -46,7 +43,6 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="entityValidator">Entity validator.</param>
     /// <param name="logger">System logger.</param>
-    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="locationRepository">Location repository.</param>
     /// <param name="initiativeRepository">Initiative repository.</param>
     public InitiativeLocationService(
@@ -55,7 +51,6 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         IValidationErrorTranslator errorTranslator,
         IValidator<InitiativeLocationDto> entityValidator,
         ILogger logger,
-        IInitiativeUserRepository initiativeUserRepository,
         ILocationRepository locationRepository,
         IInitiativeRepository initiativeRepository)
         : base(entityRepository, mapper, errorTranslator)
@@ -64,7 +59,6 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         this.mapper = mapper;
         this.entityValidator = entityValidator;
         this.logger = logger;
-        this.initiativeUserRepository = initiativeUserRepository;
         this.locationRepository = locationRepository;
         this.initiativeRepository = initiativeRepository;
     }
@@ -91,7 +85,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
 
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {
@@ -182,7 +176,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
 
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {
@@ -269,7 +263,7 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         // Validate user permissions
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {

--- a/src/Application/Services/Initiatives/InitiativeLocationService.cs
+++ b/src/Application/Services/Initiatives/InitiativeLocationService.cs
@@ -83,17 +83,12 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         // Validate user permissions
         var initiativeId = entityData.InitiativeId ?? 0;
 
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate data
@@ -174,17 +169,12 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var initiativeId = entity?.InitiativeId ?? 0;
 
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate entity
@@ -261,17 +251,12 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         var initiativeId = entity?.InitiativeId ?? 0;
 
         // Validate user permissions
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate entity

--- a/src/Application/Services/Initiatives/InitiativeLocationService.cs
+++ b/src/Application/Services/Initiatives/InitiativeLocationService.cs
@@ -86,6 +86,22 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, InitiativeLocationDto entityData, CancellationToken ct = default)
     {
+        // Validate user permissions
+        var initiativeId = entityData.InitiativeId ?? 0;
+
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
 
@@ -98,7 +114,6 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
         }
 
         // Validate initiative
-        var initiativeId = entityData.InitiativeId ?? 0;
         var initiativeExists = await initiativeRepository.AnyAsync(initiativeId, ct);
 
         if (!initiativeExists)
@@ -107,20 +122,6 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Initiatives.NotFound),
             };
-        }
-
-        // Validate user permissions
-        if (!userIsAdmin)
-        {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-            if (!authorizedUserAction)
-            {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
         }
 
         // Validate location
@@ -175,6 +176,32 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeLocationDto entityData, CancellationToken ct = default)
     {
+        // Validate user permissions
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var initiativeId = entity?.InitiativeId ?? 0;
+
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
@@ -184,31 +211,6 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
             {
                 ResponseBody = errorTranslator.Translate(validationResult.Errors),
             };
-        }
-
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user permissions
-        if (!userIsAdmin)
-        {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-            if (!authorizedUserAction)
-            {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
         }
 
         // Validate location
@@ -261,21 +263,13 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
     {
-        // Validate entity
         var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
+        var initiativeId = entity?.InitiativeId ?? 0;
 
         // Validate user permissions
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
 
             if (!authorizedUserAction)
             {
@@ -284,6 +278,15 @@ public class InitiativeLocationService : ServiceRead<InitiativeLocation, Initiat
                     StatusCode = HttpStatusCode.Forbidden,
                 };
             }
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
         }
 
         // Validate number of locations

--- a/src/Application/Services/Initiatives/InitiativeService.cs
+++ b/src/Application/Services/Initiatives/InitiativeService.cs
@@ -51,7 +51,6 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
     private readonly ILogger logger;
     private new readonly IMapperCreateReadAndUpdate<Initiative, InitiativeDto> mapper;
     private new readonly IInitiativeRepository entityRepository;
-    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly ILocationRepository locationRepository;
     private readonly ILocationService locationService;
     private readonly IIamService iamService;
@@ -68,7 +67,6 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="entityValidator">Entity validator.</param>
     /// <param name="logger">System logger.</param>
-    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="locationRepository">Initiative Location repository.</param>
     /// <param name="locationService">Location service.</param>
     /// <param name="iamService">IAM service.</param>
@@ -80,7 +78,6 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
         IValidationErrorTranslator errorTranslator,
         IValidator<InitiativeDto> entityValidator,
         ILogger logger,
-        IInitiativeUserRepository initiativeUserRepository,
         ILocationRepository locationRepository,
         ILocationService locationService,
         IIamService iamService,
@@ -92,7 +89,6 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
         this.mapper = mapper;
         this.entityValidator = entityValidator;
         this.logger = logger;
-        this.initiativeUserRepository = initiativeUserRepository;
         this.locationRepository = locationRepository;
         this.locationService = locationService;
         this.iamService = iamService;
@@ -290,7 +286,7 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
         // Validate user permissions
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(id, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
             if (!authorizedUserAction)
             {

--- a/src/Application/Services/Initiatives/InitiativeService.cs
+++ b/src/Application/Services/Initiatives/InitiativeService.cs
@@ -284,17 +284,12 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeDto entityData, CancellationToken ct = default)
     {
         // Validate user permissions
-        if (!userIsAdmin)
+        if (!await entityRepository.AuthorizedEntityModifyAsync(id, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate data

--- a/src/Application/Services/Initiatives/InitiativeService.cs
+++ b/src/Application/Services/Initiatives/InitiativeService.cs
@@ -51,6 +51,7 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
     private readonly ILogger logger;
     private new readonly IMapperCreateReadAndUpdate<Initiative, InitiativeDto> mapper;
     private new readonly IInitiativeRepository entityRepository;
+    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly ILocationRepository locationRepository;
     private readonly ILocationService locationService;
     private readonly IIamService iamService;
@@ -67,6 +68,7 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="entityValidator">Entity validator.</param>
     /// <param name="logger">System logger.</param>
+    /// <param name="initiativeUserRepository">Initiative user repository</param>
     /// <param name="locationRepository">Initiative Location repository.</param>
     /// <param name="locationService">Location service.</param>
     /// <param name="iamService">IAM service.</param>
@@ -78,6 +80,7 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
         IValidationErrorTranslator errorTranslator,
         IValidator<InitiativeDto> entityValidator,
         ILogger logger,
+        IInitiativeUserRepository initiativeUserRepository,
         ILocationRepository locationRepository,
         ILocationService locationService,
         IIamService iamService,
@@ -89,6 +92,7 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
         this.mapper = mapper;
         this.entityValidator = entityValidator;
         this.logger = logger;
+        this.initiativeUserRepository = initiativeUserRepository;
         this.locationRepository = locationRepository;
         this.locationService = locationService;
         this.iamService = iamService;
@@ -281,7 +285,7 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> UpdateAsync(int id, InitiativeDto entityData, CancellationToken ct = default)
+    public async Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeDto entityData, CancellationToken ct = default)
     {
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
@@ -314,6 +318,20 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(id, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Update entity data

--- a/src/Application/Services/Initiatives/InitiativeService.cs
+++ b/src/Application/Services/Initiatives/InitiativeService.cs
@@ -287,6 +287,20 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, bool userIsAdmin, InitiativeDto entityData, CancellationToken ct = default)
     {
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(id, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
@@ -318,20 +332,6 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
-        }
-
-        // Validate user permissions
-        if (!userIsAdmin)
-        {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(id, userName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-            if (!authorizedUserAction)
-            {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
         }
 
         // Update entity data

--- a/src/Application/Services/Initiatives/InitiativeService.cs
+++ b/src/Application/Services/Initiatives/InitiativeService.cs
@@ -68,7 +68,7 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="entityValidator">Entity validator.</param>
     /// <param name="logger">System logger.</param>
-    /// <param name="initiativeUserRepository">Initiative user repository</param>
+    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="locationRepository">Initiative Location repository.</param>
     /// <param name="locationService">Location service.</param>
     /// <param name="iamService">IAM service.</param>

--- a/src/Application/Services/Initiatives/InitiativeTagService.cs
+++ b/src/Application/Services/Initiatives/InitiativeTagService.cs
@@ -19,8 +19,6 @@ using Serilog;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.LogEnums;
 
-using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
-
 /// <summary>
 /// Initiative Tag service.
 /// </summary>
@@ -30,7 +28,6 @@ public class InitiativeTagService : IInitiativeTagService
     private readonly IValidationErrorTranslator errorTranslator;
     private readonly ILogger logger;
     private readonly IMapperRead<InitiativeTag, InitiativeTagDto> mapper;
-    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly IInitiativeRepository initiativeRepository;
     private readonly ITagRepository tagRepository;
 
@@ -41,7 +38,6 @@ public class InitiativeTagService : IInitiativeTagService
     /// <param name="mapper">Entity mapper.</param>
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="logger">System logger.</param>
-    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="initiativeRepository">Initiative repository.</param>
     /// <param name="tagRepository">Tag repository.</param>
     public InitiativeTagService(
@@ -49,7 +45,6 @@ public class InitiativeTagService : IInitiativeTagService
         IMapperRead<InitiativeTag, InitiativeTagDto> mapper,
         IValidationErrorTranslator errorTranslator,
         ILogger logger,
-        IInitiativeUserRepository initiativeUserRepository,
         IInitiativeRepository initiativeRepository,
         ITagRepository tagRepository)
     {
@@ -57,7 +52,6 @@ public class InitiativeTagService : IInitiativeTagService
         this.mapper = mapper;
         this.errorTranslator = errorTranslator;
         this.logger = logger;
-        this.initiativeUserRepository = initiativeUserRepository;
         this.initiativeRepository = initiativeRepository;
         this.tagRepository = tagRepository;
     }
@@ -68,7 +62,7 @@ public class InitiativeTagService : IInitiativeTagService
         // Validate user permissions
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {
@@ -140,7 +134,7 @@ public class InitiativeTagService : IInitiativeTagService
 
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {

--- a/src/Application/Services/Initiatives/InitiativeTagService.cs
+++ b/src/Application/Services/Initiatives/InitiativeTagService.cs
@@ -57,6 +57,7 @@ public class InitiativeTagService : IInitiativeTagService
         this.mapper = mapper;
         this.errorTranslator = errorTranslator;
         this.logger = logger;
+        this.initiativeUserRepository = initiativeUserRepository;
         this.initiativeRepository = initiativeRepository;
         this.tagRepository = tagRepository;
     }
@@ -64,17 +65,6 @@ public class InitiativeTagService : IInitiativeTagService
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, int initiativeId, int tagId, CancellationToken ct = default)
     {
-        // Validate initiative
-        var initiativeExists = await initiativeRepository.AnyAsync(initiativeId, ct);
-
-        if (!initiativeExists)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Initiatives.NotFound),
-            };
-        }
-
         // Validate user permissions
         if (!userIsAdmin)
         {
@@ -87,6 +77,17 @@ public class InitiativeTagService : IInitiativeTagService
                     StatusCode = HttpStatusCode.Forbidden,
                 };
             }
+        }
+
+        // Validate initiative
+        var initiativeExists = await initiativeRepository.AnyAsync(initiativeId, ct);
+
+        if (!initiativeExists)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Initiatives.NotFound),
+            };
         }
 
         // Validate tag
@@ -133,21 +134,13 @@ public class InitiativeTagService : IInitiativeTagService
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
     {
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
         // Validate user permissions
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var initiativeId = entity?.InitiativeId ?? 0;
+
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
 
             if (!authorizedUserAction)
             {
@@ -156,6 +149,15 @@ public class InitiativeTagService : IInitiativeTagService
                     StatusCode = HttpStatusCode.Forbidden,
                 };
             }
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
         }
 
         await entityRepository.DeleteAsync(entity, ct);

--- a/src/Application/Services/Initiatives/InitiativeTagService.cs
+++ b/src/Application/Services/Initiatives/InitiativeTagService.cs
@@ -60,17 +60,12 @@ public class InitiativeTagService : IInitiativeTagService
     public async Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, int initiativeId, int tagId, CancellationToken ct = default)
     {
         // Validate user permissions
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate initiative
@@ -132,17 +127,12 @@ public class InitiativeTagService : IInitiativeTagService
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var initiativeId = entity?.InitiativeId ?? 0;
 
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate entity

--- a/src/Application/Services/Initiatives/InitiativeTagService.cs
+++ b/src/Application/Services/Initiatives/InitiativeTagService.cs
@@ -1,5 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.Application.Services.Initiatives;
 
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,6 +19,8 @@ using Serilog;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.LogEnums;
 
+using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
+
 /// <summary>
 /// Initiative Tag service.
 /// </summary>
@@ -27,6 +30,7 @@ public class InitiativeTagService : IInitiativeTagService
     private readonly IValidationErrorTranslator errorTranslator;
     private readonly ILogger logger;
     private readonly IMapperRead<InitiativeTag, InitiativeTagDto> mapper;
+    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly IInitiativeRepository initiativeRepository;
     private readonly ITagRepository tagRepository;
 
@@ -37,6 +41,7 @@ public class InitiativeTagService : IInitiativeTagService
     /// <param name="mapper">Entity mapper.</param>
     /// <param name="errorTranslator">Error translator.</param>
     /// <param name="logger">System logger.</param>
+    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="initiativeRepository">Initiative repository.</param>
     /// <param name="tagRepository">Tag repository.</param>
     public InitiativeTagService(
@@ -44,6 +49,7 @@ public class InitiativeTagService : IInitiativeTagService
         IMapperRead<InitiativeTag, InitiativeTagDto> mapper,
         IValidationErrorTranslator errorTranslator,
         ILogger logger,
+        IInitiativeUserRepository initiativeUserRepository,
         IInitiativeRepository initiativeRepository,
         ITagRepository tagRepository)
     {
@@ -56,7 +62,7 @@ public class InitiativeTagService : IInitiativeTagService
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> AddAsync(int initiativeId, int tagId, CancellationToken ct = default)
+    public async Task<CustomWebResponse> AddAsync(string userName, bool userIsAdmin, int initiativeId, int tagId, CancellationToken ct = default)
     {
         // Validate initiative
         var initiativeExists = await initiativeRepository.AnyAsync(initiativeId, ct);
@@ -67,6 +73,20 @@ public class InitiativeTagService : IInitiativeTagService
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Initiatives.NotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         // Validate tag
@@ -111,7 +131,7 @@ public class InitiativeTagService : IInitiativeTagService
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> DeleteAsync(int id, CancellationToken ct = default)
+    public async Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
     {
         // Validate entity
         var entity = await entityRepository.GetByIdAsync(id, ct);
@@ -122,6 +142,20 @@ public class InitiativeTagService : IInitiativeTagService
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
+        }
+
+        // Validate user permissions
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
         }
 
         await entityRepository.DeleteAsync(entity, ct);

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -177,17 +177,12 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var initiativeId = entity?.InitiativeId ?? 0;
 
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, reviewerUserName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, reviewerUserName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate entity
@@ -256,17 +251,12 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var initiativeId = entity?.InitiativeId ?? 0;
 
-        if (!userIsAdmin)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, userIsAdmin, ct))
         {
-            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-            if (!authorizedUserAction)
+            return new(true)
             {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
+                StatusCode = HttpStatusCode.Forbidden,
+            };
         }
 
         // Validate entity

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -179,7 +179,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
 
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await entityRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, reviewerUserName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, reviewerUserName, ct);
 
             if (!authorizedUserAction)
             {
@@ -258,7 +258,7 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
 
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await entityRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
             if (!authorizedUserAction)
             {

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -173,6 +173,32 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string reviewerUserName, bool userIsAdmin, InitiativeUserDto entityData, CancellationToken ct = default)
     {
+        // Validate user permissions
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var initiativeId = entity?.InitiativeId ?? 0;
+
+        if (!userIsAdmin)
+        {
+            var authorizedUserAction = await entityRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, reviewerUserName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+            if (!authorizedUserAction)
+            {
+                return new(true)
+                {
+                    StatusCode = HttpStatusCode.Forbidden,
+                };
+            }
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
@@ -182,31 +208,6 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
             {
                 ResponseBody = errorTranslator.Translate(validationResult.Errors),
             };
-        }
-
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user permissions
-        if (!userIsAdmin)
-        {
-            var authorizedUserAction = await entityRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, reviewerUserName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-            if (!authorizedUserAction)
-            {
-                return new(true)
-                {
-                    StatusCode = HttpStatusCode.Forbidden,
-                };
-            }
         }
 
         // Validate number of leaders
@@ -251,21 +252,13 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
     {
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
         // Validate user permissions
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var initiativeId = entity?.InitiativeId ?? 0;
+
         if (!userIsAdmin)
         {
-            var authorizedUserAction = await entityRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+            var authorizedUserAction = await entityRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
 
             if (!authorizedUserAction)
             {
@@ -274,6 +267,15 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
                     StatusCode = HttpStatusCode.Forbidden,
                 };
             }
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
         }
 
         // Validate number of leaders

--- a/src/Application/Services/Initiatives/JoinInvitationService.cs
+++ b/src/Application/Services/Initiatives/JoinInvitationService.cs
@@ -28,8 +28,6 @@ using Serilog;
 
 using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.LogEnums;
 
-using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
-
 /// <summary>
 /// Join Invitation service.
 /// </summary>
@@ -40,7 +38,6 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
     private readonly ILogger logger;
     private new readonly IMapperCreateAndRead<JoinInvitation, JoinInvitationDto> mapper;
     private readonly IInitiativeRepository initiativeRepository;
-    private readonly IInitiativeUserRepository initiativeUserRepository;
     private readonly IWebViewTools webViewTools;
     private readonly IEmailService emailService;
     private readonly IIamService iamService;
@@ -54,7 +51,6 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
     /// <param name="entityValidator">Entity validator.</param>
     /// <param name="logger">System logger.</param>
     /// <param name="initiativeRepository">Initiative repository.</param>
-    /// <param name="initiativeUserRepository">Initiative user repository.</param>
     /// <param name="webViewTools">Web View Tools.</param>
     /// <param name="emailService">Email service.</param>
     /// <param name="iamService">IAM service.</param>
@@ -65,7 +61,6 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
         IValidator<JoinInvitationDto> entityValidator,
         ILogger logger,
         IInitiativeRepository initiativeRepository,
-        IInitiativeUserRepository initiativeUserRepository,
         IWebViewTools webViewTools,
         IEmailService emailService,
         IIamService iamService)
@@ -76,7 +71,6 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
         this.entityValidator = entityValidator;
         this.logger = logger;
         this.initiativeRepository = initiativeRepository;
-        this.initiativeUserRepository = initiativeUserRepository;
         this.webViewTools = webViewTools;
         this.emailService = emailService;
         this.iamService = iamService;
@@ -86,9 +80,9 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
     public async Task<CustomWebResponse> GetListAsync(int initiativeId, string userName, ODataQueryOptions<JoinInvitation> queryOptions, CancellationToken ct = default)
     {
         // Validate user level
-        var userIsLeader = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+        var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
-        if (!userIsLeader)
+        if (!authorizedUserAction)
         {
             return new(true)
             {
@@ -106,10 +100,10 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(JoinInvitationDto entityData, CancellationToken ct = default)
     {
-        // Validate user role and initiative relationship
-        var userIsLeader = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entityData.InitiativeId, entityData.Creator, (int)InitiativeUserLevelEnum.Leader, ct);
+        // Validate user permissions
+        var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(entityData.InitiativeId, entityData.Creator, ct);
 
-        if (!userIsLeader)
+        if (!authorizedUserAction)
         {
             return new(true)
             {

--- a/src/Application/Services/Initiatives/JoinInvitationService.cs
+++ b/src/Application/Services/Initiatives/JoinInvitationService.cs
@@ -80,9 +80,7 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
     public async Task<CustomWebResponse> GetListAsync(int initiativeId, string userName, ODataQueryOptions<JoinInvitation> queryOptions, CancellationToken ct = default)
     {
         // Validate user level
-        var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-        if (!authorizedUserAction)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, false, ct))
         {
             return new(true)
             {
@@ -101,9 +99,7 @@ public class JoinInvitationService : ServiceRead<JoinInvitation, JoinInvitationD
     public async Task<CustomWebResponse> AddAsync(JoinInvitationDto entityData, CancellationToken ct = default)
     {
         // Validate user permissions
-        var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(entityData.InitiativeId, entityData.Creator, ct);
-
-        if (!authorizedUserAction)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(entityData.InitiativeId, entityData.Creator, false, ct))
         {
             return new(true)
             {

--- a/src/Application/Services/Initiatives/JoinRequestService.cs
+++ b/src/Application/Services/Initiatives/JoinRequestService.cs
@@ -90,9 +90,9 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int>,
     public async Task<CustomWebResponse> GetListAsync(int initiativeId, string userName, ODataQueryOptions<JoinRequest> queryOptions, CancellationToken ct = default)
     {
         // Validate user level
-        var userIsLeader = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+        var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
 
-        if (!userIsLeader)
+        if (!authorizedUserAction)
         {
             return new(true)
             {
@@ -210,20 +210,21 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int>,
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, JoinRequestDto entityData, CancellationToken ct = default)
     {
-        // Validate data
-        var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Update"), ct);
+        // Validate user level
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var initiativeId = entity?.InitiativeId ?? 0;
 
-        if (!validationResult.IsValid)
+        var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, entityData.ReviewerUserName, ct);
+
+        if (!authorizedUserAction)
         {
             return new(true)
             {
-                ResponseBody = errorTranslator.Translate(validationResult.Errors),
+                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
         // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
         if (entity == null)
         {
             return new(true)
@@ -232,22 +233,22 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int>,
             };
         }
 
-        // Validate user level
-        var userIsLeader = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, entityData.ReviewerUserName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-        if (!userIsLeader)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
-            };
-        }
-
         if (entity.StatusId != (int)JoinRequestStatusEnum.UnderReview)
         {
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.JoinRequests.ReviewedJoinRequests),
+            };
+        }
+
+        // Validate data
+        var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Update"), ct);
+
+        if (!validationResult.IsValid)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(validationResult.Errors),
             };
         }
 

--- a/src/Application/Services/Initiatives/JoinRequestService.cs
+++ b/src/Application/Services/Initiatives/JoinRequestService.cs
@@ -90,9 +90,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int>,
     public async Task<CustomWebResponse> GetListAsync(int initiativeId, string userName, ODataQueryOptions<JoinRequest> queryOptions, CancellationToken ct = default)
     {
         // Validate user level
-        var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, ct);
-
-        if (!authorizedUserAction)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, userName, false, ct))
         {
             return new(true)
             {
@@ -214,9 +212,7 @@ public class JoinRequestService : ServiceRead<JoinRequest, JoinRequestDto, int>,
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var initiativeId = entity?.InitiativeId ?? 0;
 
-        var authorizedUserAction = await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, entityData.ReviewerUserName, ct);
-
-        if (!authorizedUserAction)
+        if (!await initiativeRepository.AuthorizedEntityModifyAsync(initiativeId, entityData.ReviewerUserName, false, ct))
         {
             return new(true)
             {

--- a/src/Application/Services/Resources/ResourceFileService.cs
+++ b/src/Application/Services/Resources/ResourceFileService.cs
@@ -81,7 +81,7 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, ResourceFileDto entityData, IInputFile formFile, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var resourceId = entityData?.ResourceId ?? 0;
 
         var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
@@ -172,7 +172,7 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, ResourceFileDto entityData, IInputFile formFile, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 
@@ -256,7 +256,7 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 

--- a/src/Application/Services/Resources/ResourceFileService.cs
+++ b/src/Application/Services/Resources/ResourceFileService.cs
@@ -81,6 +81,19 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, ResourceFileDto entityData, IInputFile formFile, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var resourceId = entityData?.ResourceId ?? 0;
+
+        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
 
@@ -100,17 +113,6 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Resources.NotFound),
-            };
-        }
-
-        // Validate user level and permissions
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(entityData.ResourceId, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
@@ -170,6 +172,29 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, ResourceFileDto entityData, IInputFile formFile, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var resourceId = entity?.ResourceId ?? 0;
+
+        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
@@ -202,28 +227,6 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
             }
         }
 
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user level and permissions
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(entity.ResourceId, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
-            };
-        }
-
         // Update entity data
         mapper.Update(entity, entityData);
 
@@ -253,25 +256,26 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
         // Validate user level and permissions
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(entity.ResourceId, userName, ct);
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var resourceId = entity?.ResourceId ?? 0;
+
+        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {
             return new(true)
             {
                 StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
         }
 

--- a/src/Application/Services/Resources/ResourceFileService.cs
+++ b/src/Application/Services/Resources/ResourceFileService.cs
@@ -84,7 +84,7 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
         // Validate user level and permissions
         var resourceId = entityData?.ResourceId ?? 0;
 
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {
@@ -176,7 +176,7 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {
@@ -260,7 +260,7 @@ public class ResourceFileService : ServiceRead<ResourceFile, ResourceFileDto, in
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {

--- a/src/Application/Services/Resources/ResourceLinkService.cs
+++ b/src/Application/Services/Resources/ResourceLinkService.cs
@@ -86,6 +86,18 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, ResourceLinkDto entityData, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var resourceId = entityData?.ResourceId ?? 0;
+        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
 
@@ -105,17 +117,6 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Resources.NotFound),
-            };
-        }
-
-        // Validate user permissions
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(entityData.ResourceId.Value, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
@@ -172,20 +173,21 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, ResourceLinkDto entityData, CancellationToken ct = default)
     {
-        // Validate data
-        var validationResult = await entityValidator.ValidateAsync(entityData, ct);
+        // Validate user level and permissions
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var resourceId = entity?.ResourceId ?? 0;
 
-        if (!validationResult.IsValid)
+        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+
+        if (!authorizedUserAction)
         {
             return new(true)
             {
-                ResponseBody = errorTranslator.Translate(validationResult.Errors),
+                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
         // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
         if (entity == null)
         {
             return new(true)
@@ -194,14 +196,14 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
             };
         }
 
-        // Validate user permissions
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(entity.ResourceId, userName, ct);
+        // Validate data
+        var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
-        if (!authorizedUserAction)
+        if (!validationResult.IsValid)
         {
             return new(true)
             {
-                StatusCode = HttpStatusCode.Forbidden,
+                ResponseBody = errorTranslator.Translate(validationResult.Errors),
             };
         }
 
@@ -249,25 +251,26 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate entity
+        // Validate user level and permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
+        var resourceId = entity?.ResourceId ?? 0;
 
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user permissions
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(entity.ResourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {
             return new(true)
             {
                 StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
         }
 

--- a/src/Application/Services/Resources/ResourceLinkService.cs
+++ b/src/Application/Services/Resources/ResourceLinkService.cs
@@ -88,7 +88,7 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
     {
         // Validate user level and permissions
         var resourceId = entityData?.ResourceId ?? 0;
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {
@@ -177,7 +177,7 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {
@@ -255,7 +255,7 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {

--- a/src/Application/Services/Resources/ResourceLinkService.cs
+++ b/src/Application/Services/Resources/ResourceLinkService.cs
@@ -86,7 +86,7 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, ResourceLinkDto entityData, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var resourceId = entityData?.ResourceId ?? 0;
         var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
@@ -173,7 +173,7 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, ResourceLinkDto entityData, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 
@@ -251,7 +251,7 @@ public class ResourceLinkService : ServiceRead<ResourceLink, ResourceLinkDto, in
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 

--- a/src/Application/Services/Resources/ResourceService.cs
+++ b/src/Application/Services/Resources/ResourceService.cs
@@ -99,7 +99,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
 
         if (entity != null)
         {
-            var userBelongsToInitiative = await entityRepository.UserRelationshipExistsAsync(id, userName, ct);
+            var userBelongsToInitiative = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
             if (!userBelongsToInitiative && entity.IsDraft)
             {
@@ -244,7 +244,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, ResourceDto entityData, CancellationToken ct = default)
     {
         // Validate user level and permissions
-        var authorizedUserAction = await entityRepository.UserRelationshipExistsAsync(id, userName, ct);
+        var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)
         {
@@ -366,7 +366,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
         // Validate user level and permissions
-        var authorizedUserAction = await entityRepository.UserRelationshipExistsAsync(id, userName, ct);
+        var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)
         {

--- a/src/Application/Services/Resources/ResourceService.cs
+++ b/src/Application/Services/Resources/ResourceService.cs
@@ -94,7 +94,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     /// <inheritdoc/>
     public async Task<CustomWebResponse> GetItemAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
 
         if (entity != null)
@@ -161,7 +161,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, ResourceDto entityData, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entityData.InitiativeId.Value, userName, null, ct);
 
         if (!authorizedUserAction)
@@ -243,7 +243,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, ResourceDto entityData, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)
@@ -365,7 +365,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)

--- a/src/Application/Services/Resources/ResourceService.cs
+++ b/src/Application/Services/Resources/ResourceService.cs
@@ -161,7 +161,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, ResourceDto entityData, CancellationToken ct = default)
     {
-        // Validate user permissions
+        // Validate user level and permissions
         var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entityData.InitiativeId.Value, userName, null, ct);
 
         if (!authorizedUserAction)
@@ -243,6 +243,17 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, ResourceDto entityData, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var authorizedUserAction = await entityRepository.UserRelationshipExistsAsync(id, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
@@ -262,17 +273,6 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user level and permissions
-        var authorizedUserAction = await entityRepository.UserRelationshipExistsAsync(id, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
@@ -319,7 +319,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     /// <inheritdoc/>
     public async Task<CustomWebResponse> LikeActionAsync(ResourceLikeDto entityData, CancellationToken ct = default)
     {
-        // Validate Territory Story
+        // Validate entity
         var entity = await entityRepository.GetByIdAsync(entityData.ResourceId, ct);
 
         if (entity == null)
@@ -365,6 +365,17 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var authorizedUserAction = await entityRepository.UserRelationshipExistsAsync(id, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate entity
         var entity = await entityRepository.GetByIdAsync(id, ct);
 
@@ -373,17 +384,6 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user permissions
-        var authorizedUserAction = await entityRepository.UserRelationshipExistsAsync(id, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 

--- a/src/Application/Services/Resources/ResourceTagService.cs
+++ b/src/Application/Services/Resources/ResourceTagService.cs
@@ -132,25 +132,26 @@ public class ResourceTagService : IResourceTagService
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
         // Validate user permissions
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(entity.ResourceId, userName, ct);
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+        var resourceId = entity?.ResourceId ?? 0;
+
+        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {
             return new(true)
             {
                 StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        // Validate entity
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
         }
 

--- a/src/Application/Services/Resources/ResourceTagService.cs
+++ b/src/Application/Services/Resources/ResourceTagService.cs
@@ -64,7 +64,7 @@ public class ResourceTagService : IResourceTagService
     public async Task<CustomWebResponse> AddAsync(string userName, int resourceId, int tagId, CancellationToken ct = default)
     {
         // Validate user permissions
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {
@@ -136,7 +136,7 @@ public class ResourceTagService : IResourceTagService
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var resourceId = entity?.ResourceId ?? 0;
 
-        var authorizedUserAction = await resourceRepository.UserRelationshipExistsAsync(resourceId, userName, ct);
+        var authorizedUserAction = await resourceRepository.AuthorizedEntityModifyAsync(resourceId, userName, ct);
 
         if (!authorizedUserAction)
         {

--- a/src/Application/Services/TerritoryStories/TerritoryStoryImageService.cs
+++ b/src/Application/Services/TerritoryStories/TerritoryStoryImageService.cs
@@ -108,6 +108,18 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, TerritoryStoryImageDto entityData, IInputFile formFile, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var territoryStoryId = entityData?.TerritoryStoryId ?? 0;
+        var authorizedUserAction = await territoryStoryRepository.AuthorizedEntityModifyAsync(territoryStoryId, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
 
@@ -120,7 +132,6 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
         }
 
         // Validate territory story
-        var territoryStoryId = entityData.TerritoryStoryId ?? 0;
         var territoryStory = await territoryStoryRepository.GetByIdAsync(territoryStoryId, ct);
 
         if (territoryStory == null)
@@ -136,17 +147,6 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.TerritoryStories.Disabled),
-            };
-        }
-
-        // Validate user level and permissions
-        var authorizedUserAction = await territoryStoryRepository.AuthorizedEntityModifyAsync(entityData.TerritoryStoryId.Value, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
@@ -207,6 +207,17 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, TerritoryStoryImageDto entityData, IInputFile formFile, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
@@ -248,17 +259,6 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user level and permissions
-        var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
@@ -310,17 +310,6 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> FeaturedContentActionAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
         // Validate user level and permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
@@ -329,6 +318,17 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
             return new(true)
             {
                 StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        // Validate entity
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
         }
 
@@ -368,17 +368,6 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
         // Validate user level and permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
@@ -387,6 +376,17 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
             return new(true)
             {
                 StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        // Validate entity
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
         }
 

--- a/src/Application/Services/TerritoryStories/TerritoryStoryImageService.cs
+++ b/src/Application/Services/TerritoryStories/TerritoryStoryImageService.cs
@@ -72,7 +72,7 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> GetItemAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entityExists = await entityRepository.AnyAsync(id, ct);
 
         if (entityExists)
@@ -108,7 +108,7 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, TerritoryStoryImageDto entityData, IInputFile formFile, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var territoryStoryId = entityData?.TerritoryStoryId ?? 0;
         var authorizedUserAction = await territoryStoryRepository.AuthorizedEntityModifyAsync(territoryStoryId, userName, ct);
 
@@ -207,7 +207,7 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, TerritoryStoryImageDto entityData, IInputFile formFile, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)
@@ -310,7 +310,7 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> FeaturedContentActionAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)
@@ -368,7 +368,7 @@ public class TerritoryStoryImageService : ServiceRead<TerritoryStoryImage, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)

--- a/src/Application/Services/TerritoryStories/TerritoryStoryService.cs
+++ b/src/Application/Services/TerritoryStories/TerritoryStoryService.cs
@@ -152,6 +152,18 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(TerritoryStoryDto entityData, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var initiativeId = entityData?.InitiativeId ?? 0;
+        var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, entityData.AuthorUserName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
 
@@ -171,17 +183,6 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Initiatives.NotFound),
-            };
-        }
-
-        // Validate user level and permissions
-        var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entityData.InitiativeId.Value, entityData.AuthorUserName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
@@ -321,7 +322,7 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> LikeActionAsync(TerritoryStoryLikeDto entityData, CancellationToken ct = default)
     {
-        // Validate Territory Story
+        // Validate entity
         var entity = await entityRepository.GetByIdAsync(entityData.TerritoryStoryId, ct);
 
         if (entity == null)
@@ -367,9 +368,21 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> FeaturedContentActionAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate entity
+        // Validate user level and permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
+        var initiativeId = entity?.InitiativeId ?? 0;
 
+        var userIsLeader = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+
+        if (!userIsLeader)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        // Validate entity
         if (entity == null)
         {
             return new(true)
@@ -383,17 +396,6 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementDisabled),
-            };
-        }
-
-        // Validate user level and permissions
-        var userIsLeader = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entity.InitiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
-
-        if (!userIsLeader)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 

--- a/src/Application/Services/TerritoryStories/TerritoryStoryService.cs
+++ b/src/Application/Services/TerritoryStories/TerritoryStoryService.cs
@@ -85,7 +85,7 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> GetItemAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
 
         if (entity != null)
@@ -152,7 +152,7 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(TerritoryStoryDto entityData, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var initiativeId = entityData?.InitiativeId ?? 0;
         var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, entityData.AuthorUserName, (int)InitiativeUserLevelEnum.Leader, ct);
 
@@ -252,7 +252,7 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, TerritoryStoryDto entityData, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)
@@ -368,13 +368,13 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     /// <inheritdoc/>
     public async Task<CustomWebResponse> FeaturedContentActionAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entity = await entityRepository.GetByIdAsync(id, ct);
         var initiativeId = entity?.InitiativeId ?? 0;
 
-        var userIsLeader = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
+        var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, userName, (int)InitiativeUserLevelEnum.Leader, ct);
 
-        if (!userIsLeader)
+        if (!authorizedUserAction)
         {
             return new(true)
             {
@@ -437,7 +437,7 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     /// <returns>Process result.</returns>
     private async Task<CustomWebResponse> DisableOrEnableAsync(int id, string userName, bool disable, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)

--- a/src/Application/Services/TerritoryStories/TerritoryStoryVideoService.cs
+++ b/src/Application/Services/TerritoryStories/TerritoryStoryVideoService.cs
@@ -103,6 +103,18 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, TerritoryStoryVideoDto entityData, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var territoryStoryId = entityData?.TerritoryStoryId ?? 0;
+        var authorizedUserAction = await territoryStoryRepository.AuthorizedEntityModifyAsync(territoryStoryId, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, options => options.IncludeRuleSets("default", "Create"), ct);
 
@@ -115,7 +127,6 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
         }
 
         // Validate territory story
-        var territoryStoryId = entityData.TerritoryStoryId ?? 0;
         var territoryStory = await territoryStoryRepository.GetByIdAsync(territoryStoryId, ct);
 
         if (territoryStory == null)
@@ -131,17 +142,6 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.TerritoryStories.Disabled),
-            };
-        }
-
-        // Validate user level and permissions
-        var authorizedUserAction = await territoryStoryRepository.AuthorizedEntityModifyAsync(entityData.TerritoryStoryId.Value, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
@@ -186,6 +186,17 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, TerritoryStoryVideoDto entityData, CancellationToken ct = default)
     {
+        // Validate user level and permissions
+        var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
+
+        if (!authorizedUserAction)
+        {
+            return new(true)
+            {
+                StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
         // Validate data
         var validationResult = await entityValidator.ValidateAsync(entityData, ct);
 
@@ -205,17 +216,6 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
             return new(true)
             {
                 ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
-        // Validate user level and permissions
-        var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
-
-        if (!authorizedUserAction)
-        {
-            return new(true)
-            {
-                StatusCode = HttpStatusCode.Forbidden,
             };
         }
 
@@ -270,17 +270,6 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate entity
-        var entity = await entityRepository.GetByIdAsync(id, ct);
-
-        if (entity == null)
-        {
-            return new(true)
-            {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
-            };
-        }
-
         // Validate user level and permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
@@ -289,6 +278,17 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
             return new(true)
             {
                 StatusCode = HttpStatusCode.Forbidden,
+            };
+        }
+
+        // Validate entity
+        var entity = await entityRepository.GetByIdAsync(id, ct);
+
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
             };
         }
 

--- a/src/Application/Services/TerritoryStories/TerritoryStoryVideoService.cs
+++ b/src/Application/Services/TerritoryStories/TerritoryStoryVideoService.cs
@@ -67,7 +67,7 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> GetItemAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var entityExists = await entityRepository.AnyAsync(id, ct);
 
         if (entityExists)
@@ -103,7 +103,7 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> AddAsync(string userName, TerritoryStoryVideoDto entityData, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var territoryStoryId = entityData?.TerritoryStoryId ?? 0;
         var authorizedUserAction = await territoryStoryRepository.AuthorizedEntityModifyAsync(territoryStoryId, userName, ct);
 
@@ -186,7 +186,7 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> UpdateAsync(int id, string userName, TerritoryStoryVideoDto entityData, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)
@@ -270,7 +270,7 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
     /// <inheritdoc/>
     public async Task<CustomWebResponse> DeleteAsync(int id, string userName, CancellationToken ct = default)
     {
-        // Validate user level and permissions
+        // Validate user permissions
         var authorizedUserAction = await entityRepository.AuthorizedEntityModifyAsync(id, userName, ct);
 
         if (!authorizedUserAction)

--- a/src/Core/Interfaces/Repositories/Initiatives/IInitiativeRepository.cs
+++ b/src/Core/Interfaces/Repositories/Initiatives/IInitiativeRepository.cs
@@ -35,9 +35,10 @@ public interface IInitiativeRepository : IRepository<Initiative, int>
     /// </summary>
     /// <param name="id">Entity identifier.</param>
     /// <param name="userName">User name.</param>
+    /// <param name="userIsAdmin">User administrator flag.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if the modification is authorized. False otherwise.</returns>
-    Task<bool> AuthorizedEntityModifyAsync(int id, string userName, CancellationToken ct = default);
+    Task<bool> AuthorizedEntityModifyAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default);
 
     /// <summary>
     /// Get if elements exists by name.

--- a/src/Core/Interfaces/Repositories/Initiatives/IInitiativeRepository.cs
+++ b/src/Core/Interfaces/Repositories/Initiatives/IInitiativeRepository.cs
@@ -31,6 +31,15 @@ public interface IInitiativeRepository : IRepository<Initiative, int>
     Task<IEnumerable<Initiative>> GetByUserNameAsync(string userName, CancellationToken ct = default);
 
     /// <summary>
+    /// Check authorized entity modification.
+    /// </summary>
+    /// <param name="id">Entity identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if the modification is authorized. False otherwise.</returns>
+    Task<bool> AuthorizedEntityModifyAsync(int id, string userName, CancellationToken ct = default);
+
+    /// <summary>
     /// Get if elements exists by name.
     /// </summary>
     /// <param name="name">Entity name.</param>

--- a/src/Core/Interfaces/Repositories/Resources/IResourceRepository.cs
+++ b/src/Core/Interfaces/Repositories/Resources/IResourceRepository.cs
@@ -22,13 +22,13 @@ public interface IResourceRepository : IRepository<Resource, int>
     Task<IQueryable<Resource>> GetQueryWithInitiativeAndUserNameAsync(int initiativeId, string userName, IQueryable<Resource> query, CancellationToken ct = default);
 
     /// <summary>
-    /// Check resource and user relationship (by initiative).
+    /// Check authorized entity modification.
     /// </summary>
     /// <param name="id">Entity identifier.</param>
     /// <param name="userName">User name.</param>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>True if the relationship exists. False otherwise.</returns>
-    Task<bool> UserRelationshipExistsAsync(int id, string userName, CancellationToken ct = default);
+    /// <returns>True if the modification is authorized. False otherwise.</returns>
+    Task<bool> AuthorizedEntityModifyAsync(int id, string userName, CancellationToken ct = default);
 
     /// <summary>
     /// Check if element is duplicated.

--- a/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
@@ -62,13 +62,20 @@ public class InitiativeRepository : Repository<Initiative, int>, IInitiativeRepo
             .ToListAsync(ct);
 
     /// <inheritdoc/>
-    public async Task<bool> AuthorizedEntityModifyAsync(int id, string userName, CancellationToken ct = default) =>
-        await dbContext.Initiatives
+    public async Task<bool> AuthorizedEntityModifyAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default)
+    {
+        if (userIsAdmin)
+        {
+            return true;
+        }
+
+        return await dbContext.Initiatives
             .Include(e => e.InitiativeUsers)
             .Where(e =>
                 e.Id == id &&
                 e.InitiativeUsers.Any(e => e.UserName == userName && e.LevelId == (int)InitiativeUserLevelEnum.Leader))
             .AnyAsync(ct);
+    }
 
     /// <inheritdoc/>
     public async Task<bool> AnyByNameAsync(string name, CancellationToken ct = default) =>

--- a/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
@@ -15,6 +15,8 @@ using NetTopologySuite.Geometries;
 
 using Serilog;
 
+using InitiativeUserLevelEnum = IAVH.BioTablero.CM.Core.Domain.Utils.Enums.InitiativesEnums.InitiativeUserLevel;
+
 /// <summary>
 /// Initiative repository.
 /// </summary>
@@ -58,6 +60,15 @@ public class InitiativeRepository : Repository<Initiative, int>, IInitiativeRepo
             .Include(e => e.InitiativeUsers.Where(u => u.UserName == userName))
             .Where(e => e.InitiativeUsers.Any(e => e.UserName == userName))
             .ToListAsync(ct);
+
+    /// <inheritdoc/>
+    public async Task<bool> AuthorizedEntityModifyAsync(int id, string userName, CancellationToken ct = default) =>
+        await dbContext.Initiatives
+            .Include(e => e.InitiativeUsers)
+            .Where(e =>
+                e.Id == id &&
+                e.InitiativeUsers.Any(e => e.UserName == userName && e.LevelId == (int)InitiativeUserLevelEnum.Leader))
+            .AnyAsync(ct);
 
     /// <inheritdoc/>
     public async Task<bool> AnyByNameAsync(string name, CancellationToken ct = default) =>

--- a/src/Infrastructure/Persistence/Repositories/Resources/ResourceRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Resources/ResourceRepository.cs
@@ -52,7 +52,7 @@ public class ResourceRepository : Repository<Resource, int>, IResourceRepository
     }
 
     /// <inheritdoc/>
-    public async Task<bool> UserRelationshipExistsAsync(int id, string userName, CancellationToken ct = default) =>
+    public async Task<bool> AuthorizedEntityModifyAsync(int id, string userName, CancellationToken ct = default) =>
         await dbContext.Resources
             .Include(e => e.Initiative)
                 .ThenInclude(e => e.InitiativeUsers)

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeContactController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeContactController.cs
@@ -5,10 +5,10 @@ using System.Threading.Tasks;
 
 using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
-using IAVH.BioTablero.CM.Core.Domain.Utils.Constants;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.InitiativeContact;
 using IAVH.BioTablero.CM.WebApi.Interfaces;
+using IAVH.BioTablero.CM.WebApi.Utils;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -63,12 +63,12 @@ public class InitiativeContactController(
     /// <returns>Added entity data.</returns>
     [HttpPost]
     [Consumes("application/json")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     [SwaggerRequestExample(typeof(InitiativeContactDto), typeof(InitiativeContactAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeContactResponseExample))]
     public async Task<IActionResult> Post([FromBody] InitiativeContactDto requestData, CancellationToken ct)
     {
-        var response = await entityService.AddAsync(requestData, ct);
+        var response = await entityService.AddAsync(HttpContext.GetUserName(), HttpContext.UserIsAdmin(), requestData, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -81,12 +81,12 @@ public class InitiativeContactController(
     /// <returns>Updated entity data.</returns>
     [HttpPut("{id}")]
     [Consumes("application/json")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     [SwaggerRequestExample(typeof(InitiativeContactDto), typeof(InitiativeContactEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeContactResponseExample))]
     public async Task<IActionResult> Put(int id, [FromBody] InitiativeContactDto requestData, CancellationToken ct)
     {
-        var response = await entityService.UpdateAsync(id, requestData, ct);
+        var response = await entityService.UpdateAsync(id, HttpContext.GetUserName(), HttpContext.UserIsAdmin(), requestData, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -97,10 +97,10 @@ public class InitiativeContactController(
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     [HttpDelete("{id}")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     public async Task<IActionResult> Delete(int id, CancellationToken ct)
     {
-        var response = await entityService.DeleteAsync(id, ct);
+        var response = await entityService.DeleteAsync(id, HttpContext.GetUserName(), HttpContext.UserIsAdmin(), ct);
         return webTools.CustomResponse(response);
     }
 }

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeController.cs
@@ -11,6 +11,7 @@ using IAVH.BioTablero.CM.Infrastructure.Integrations.Storage;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Initiative;
 using IAVH.BioTablero.CM.WebApi.Interfaces;
+using IAVH.BioTablero.CM.WebApi.Utils;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -60,6 +61,20 @@ public class InitiativeController(
     public async Task<IActionResult> GetOdataList(ODataQueryOptions<Initiative> queryOptions, CancellationToken ct)
     {
         var response = await entityService.GetListAsync(queryOptions, ct);
+        return webTools.CustomResponse(response);
+    }
+
+    /// <summary>
+    /// Get active initiatives with coordinates by location.
+    /// </summary>
+    /// <param name="locationId">Location identifier (optional). If null, returns all active initiatives.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of initiatives with coordinates.</returns>
+    [HttpGet("GetByLocation")]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeGeoDataResponseExample))]
+    public async Task<IActionResult> GetByLocation([FromQuery] int? locationId = null, CancellationToken ct = default)
+    {
+        var response = await entityService.GetByLocationAsync(locationId, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -115,12 +130,12 @@ public class InitiativeController(
     /// <returns>Updated entity data.</returns>
     [HttpPut("{id}")]
     [Consumes("application/json")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     [SwaggerRequestExample(typeof(InitiativeDto), typeof(InitiativeEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeResponseExample))]
     public async Task<IActionResult> Put(int id, [FromBody] InitiativeDto requestData, CancellationToken ct)
     {
-        var response = await entityService.UpdateAsync(id, requestData, ct);
+        var response = await entityService.UpdateAsync(id, HttpContext.GetUserName(), HttpContext.UserIsAdmin(), requestData, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -228,20 +243,6 @@ public class InitiativeController(
     public async Task<IActionResult> Disable(int id, CancellationToken ct)
     {
         var response = await entityService.DisableAsync(id, ct);
-        return webTools.CustomResponse(response);
-    }
-
-    /// <summary>
-    /// Get active initiatives with coordinates by location.
-    /// </summary>
-    /// <param name="locationId">Location identifier (optional). If null, returns all active initiatives.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>List of initiatives with coordinates.</returns>
-    [HttpGet("GetByLocation")]
-    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeGeoDataResponseExample))]
-    public async Task<IActionResult> GetByLocation([FromQuery] int? locationId = null, CancellationToken ct = default)
-    {
-        var response = await entityService.GetByLocationAsync(locationId, ct);
         return webTools.CustomResponse(response);
     }
 }

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeLocationController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeLocationController.cs
@@ -5,10 +5,10 @@ using System.Threading.Tasks;
 
 using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
-using IAVH.BioTablero.CM.Core.Domain.Utils.Constants;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.InitiativeLocation;
 using IAVH.BioTablero.CM.WebApi.Interfaces;
+using IAVH.BioTablero.CM.WebApi.Utils;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -63,12 +63,12 @@ public class InitiativeLocationController(
     /// <returns>Added entity data.</returns>
     [HttpPost]
     [Consumes("application/json")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     [SwaggerRequestExample(typeof(InitiativeLocationDto), typeof(InitiativeLocationAddRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeLocationResponseExample))]
     public async Task<IActionResult> Post([FromBody] InitiativeLocationDto requestData, CancellationToken ct)
     {
-        var response = await entityService.AddAsync(requestData, ct);
+        var response = await entityService.AddAsync(HttpContext.GetUserName(), HttpContext.UserIsAdmin(), requestData, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -81,12 +81,12 @@ public class InitiativeLocationController(
     /// <returns>Updated entity data.</returns>
     [HttpPut("{id}")]
     [Consumes("application/json")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     [SwaggerRequestExample(typeof(InitiativeLocationDto), typeof(InitiativeLocationEditRequestExample))]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeLocationResponseExample))]
     public async Task<IActionResult> Put(int id, [FromBody] InitiativeLocationDto requestData, CancellationToken ct)
     {
-        var response = await entityService.UpdateAsync(id, requestData, ct);
+        var response = await entityService.UpdateAsync(id, HttpContext.GetUserName(), HttpContext.UserIsAdmin(), requestData, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -97,10 +97,10 @@ public class InitiativeLocationController(
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     [HttpDelete("{id}")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     public async Task<IActionResult> Delete(int id, CancellationToken ct)
     {
-        var response = await entityService.DeleteAsync(id, ct);
+        var response = await entityService.DeleteAsync(id, HttpContext.GetUserName(), HttpContext.UserIsAdmin(), ct);
         return webTools.CustomResponse(response);
     }
 }

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeTagController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeTagController.cs
@@ -4,9 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
-using IAVH.BioTablero.CM.Core.Domain.Utils.Constants;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;
 using IAVH.BioTablero.CM.WebApi.Interfaces;
+using IAVH.BioTablero.CM.WebApi.Utils;
 
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -33,13 +33,13 @@ public class InitiativeTagController(
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Added entity data.</returns>
     [HttpPost]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(void), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(void), StatusCodes.Status500InternalServerError)]
     public async Task<IActionResult> Post(int initiativeId, int tagId, CancellationToken ct)
     {
-        var response = await entityService.AddAsync(initiativeId, tagId, ct);
+        var response = await entityService.AddAsync(HttpContext.GetUserName(), HttpContext.UserIsAdmin(), initiativeId, tagId, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -50,10 +50,10 @@ public class InitiativeTagController(
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     [HttpDelete("{id}")]
-    [Authorize(Roles = IamConstants.RoleModuleAdmin)]
+    [Authorize]
     public async Task<IActionResult> Delete(int id, CancellationToken ct)
     {
-        var response = await entityService.DeleteAsync(id, ct);
+        var response = await entityService.DeleteAsync(id, HttpContext.GetUserName(), HttpContext.UserIsAdmin(), ct);
         return webTools.CustomResponse(response);
     }
 }

--- a/src/WebApi/Controllers/Rest/Initiatives/InitiativeUserController.cs
+++ b/src/WebApi/Controllers/Rest/Initiatives/InitiativeUserController.cs
@@ -1,6 +1,5 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Controllers.Rest.Initiatives;
 
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -88,9 +87,7 @@ public class InitiativeUserController(
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeUserResponseExample))]
     public async Task<IActionResult> Put(int id, [FromBody] InitiativeUserDto requestData, CancellationToken ct)
     {
-        var reviewerUserName = HttpContext.GetUserName();
-        var userIsAdmin = HttpContext.GetRoles().Contains(IamConstants.RoleModuleAdmin);
-        var response = await entityService.UpdateAsync(id, reviewerUserName, userIsAdmin, requestData, ct);
+        var response = await entityService.UpdateAsync(id, HttpContext.GetUserName(), HttpContext.UserIsAdmin(), requestData, ct);
         return webTools.CustomResponse(response);
     }
 
@@ -104,8 +101,7 @@ public class InitiativeUserController(
     [Authorize]
     public async Task<IActionResult> Delete(int id, CancellationToken ct)
     {
-        var userIsAdmin = HttpContext.GetRoles().Contains(IamConstants.RoleModuleAdmin);
-        var response = await entityService.DeleteAsync(id, HttpContext.GetUserName(), userIsAdmin, ct);
+        var response = await entityService.DeleteAsync(id, HttpContext.GetUserName(), HttpContext.UserIsAdmin(), ct);
         return webTools.CustomResponse(response);
     }
 }

--- a/src/WebApi/Utils/HttpContextExtensions.cs
+++ b/src/WebApi/Utils/HttpContextExtensions.cs
@@ -33,4 +33,12 @@ public static class HttpContextExtensions
             .FindAll(ClaimTypes.Role)
             .Select(r => r.Value)
             .ToArray();
+
+    /// <summary>
+    /// Checks if the current user is an administrator.
+    /// </summary>
+    /// <param name="httpContext">Current HTTP Context.</param>
+    /// <returns>True if the user is an adminstrator. False otherwise.</returns>
+    public static bool UserIsAdmin(this HttpContext httpContext) =>
+        GetRoles(httpContext).Contains(IamConstants.RoleModuleAdmin);
 }


### PR DESCRIPTION
## 🛠️ Cambios

- Se arreglaron problemas con la edición de iniciativas. Ahora la mayoría de entidades pueden ser editadas por líderes y administradores por igual.
- Se añadieron algunas mejoras y refactorizaciones relacionadas para Relatos del territorio y Recursos.

## 📝 Tareas asociadas
Resuelve lib-525

## 🤔 Consideraciones
- Cabe recordar que algunos endpoints de iniciativas (agregar, editar o eliminar imágenes; activar, desactivar o crear iniciativas, etcétera) siguen estando restringidas para administradores
- No mezclar hasta que #32 esté aprobado y cerrado

## ✅ Verificaciones
- No aplica.