### PR TITLE
Endpoints de salud

### DIFF
--- a/src/Core/Domain/Models/Email/SmtpConfigData.cs
+++ b/src/Core/Domain/Models/Email/SmtpConfigData.cs
@@ -1,0 +1,42 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Models.Email;
+
+/// <summary>
+/// SMTP configuration data.
+/// </summary>
+public class SmtpConfigData
+{
+    /// <summary>
+    /// SMTP Host.
+    /// </summary>
+    public string Host { get; set; }
+
+    /// <summary>
+    /// SMTP Port.
+    /// </summary>
+    public int Port { get; set; }
+
+    /// <summary>
+    /// Enable SSL flag.
+    /// </summary>
+    public bool EnableSsl { get; set; }
+
+    /// <summary>
+    /// SMTP User.
+    /// </summary>
+    public string User { get; set; }
+
+    /// <summary>
+    /// /SMTP Password.
+    /// </summary>
+    public string Password { get; set; }
+
+    /// <summary>
+    /// Sender's email.
+    /// </summary>
+    public string From { get; set; }
+
+    /// <summary>
+    /// Sender's name.
+    /// </summary>
+    public string FromName { get; set; }
+}

--- a/src/Infrastructure/Integrations/Email/EmailService.cs
+++ b/src/Infrastructure/Integrations/Email/EmailService.cs
@@ -23,13 +23,7 @@ using static IAVH.BioTablero.CM.Core.Domain.Utils.Enums.LogEnums;
 public class EmailService : IEmailService
 {
     private readonly ILogger logger;
-    private readonly string smtpHost;
-    private readonly int smtpPort;
-    private readonly string smtpFrom;
-    private readonly string smtpFromName;
-    private readonly string smtpUser;
-    private readonly string smtpPass;
-    private readonly bool smtpEnableSsl;
+    private readonly SmtpConfigData smtpData;
 
     /// <summary>
     /// Constructor.
@@ -39,23 +33,7 @@ public class EmailService : IEmailService
     public EmailService(ILogger logger)
     {
         this.logger = logger;
-        smtpHost = Environment.GetEnvironmentVariable("SMTP_HOST");
-        smtpUser = Environment.GetEnvironmentVariable("SMTP_USER");
-        smtpPass = Environment.GetEnvironmentVariable("SMTP_PASS");
-        smtpFrom = Environment.GetEnvironmentVariable("SMTP_FROM");
-        smtpFromName = Environment.GetEnvironmentVariable("SMTP_FROM_NAME");
-
-        var smtpStr = Environment.GetEnvironmentVariable("SMTP_PORT");
-        if (!int.TryParse(smtpStr, out smtpPort))
-        {
-            throw new InvalidCastException($"Invalid SMTP port value: '{smtpStr}'");
-        }
-
-        var smtpEnableSslStr = Environment.GetEnvironmentVariable("SMTP_ENABLED_SSL");
-        if (!bool.TryParse(smtpEnableSslStr, out smtpEnableSsl))
-        {
-            smtpEnableSsl = true;
-        }
+        smtpData = InitSmtpData();
     }
 
     /// <inheritdoc/>
@@ -63,18 +41,18 @@ public class EmailService : IEmailService
     {
         var options = SecureSocketOptions.StartTls;
 
-        if (!smtpEnableSsl)
+        if (!smtpData.EnableSsl)
         {
             options = SecureSocketOptions.None;
         }
 
         using var client = new SmtpClient();
 
-        await client.ConnectAsync(smtpHost, smtpPort, options, ct);
+        await client.ConnectAsync(smtpData.Host, smtpData.Port, options, ct);
 
-        if (!string.IsNullOrEmpty(smtpUser))
+        if (!string.IsNullOrEmpty(smtpData.User))
         {
-            await client.AuthenticateAsync(smtpUser, smtpPass, ct);
+            await client.AuthenticateAsync(smtpData.User, smtpData.Password, ct);
         }
 
         var builder = new BodyBuilder
@@ -87,7 +65,7 @@ public class EmailService : IEmailService
             Subject = subject,
             Body = builder.ToMessageBody(),
         };
-        mail.From.Add(new MailboxAddress(smtpFromName, smtpFrom));
+        mail.From.Add(new MailboxAddress(smtpData.FromName, smtpData.From));
         mail.Cc.AddRange(receivers.Select(r => new MailboxAddress(r.Name, r.Email)));
 
         if (hiddenReceivers?.Length > 0)
@@ -100,7 +78,7 @@ public class EmailService : IEmailService
         var emailData = new
         {
             Subject = subject,
-            From = smtpFrom,
+            From = smtpData.From,
             Body = body,
             Cc = receivers,
             Bcc = hiddenReceivers,
@@ -113,5 +91,38 @@ public class EmailService : IEmailService
             .Information("Sended email: {@EmailData}", emailData);
 
         return serverResponse;
+    }
+
+    /// <summary>
+    /// Initialize SMTP data.
+    /// </summary>
+    /// <returns>SMTP data object.</returns>
+    public static SmtpConfigData InitSmtpData()
+    {
+        var smtpData = new SmtpConfigData()
+        {
+            Host = Environment.GetEnvironmentVariable("SMTP_HOST"),
+            User = Environment.GetEnvironmentVariable("SMTP_USER"),
+            Password = Environment.GetEnvironmentVariable("SMTP_PASS"),
+            From = Environment.GetEnvironmentVariable("SMTP_FROM"),
+            FromName = Environment.GetEnvironmentVariable("SMTP_FROM_NAME"),
+        };
+
+        var smtpStr = Environment.GetEnvironmentVariable("SMTP_PORT");
+        if (!int.TryParse(smtpStr, out int smtpPort))
+        {
+            throw new InvalidCastException($"Invalid SMTP port value: '{smtpStr}'");
+        }
+
+        var smtpEnableSslStr = Environment.GetEnvironmentVariable("SMTP_ENABLED_SSL");
+        if (!bool.TryParse(smtpEnableSslStr, out bool smtpEnableSsl))
+        {
+            smtpEnableSsl = true;
+        }
+
+        smtpData.Port = smtpPort;
+        smtpData.EnableSsl = smtpEnableSsl;
+
+        return smtpData;
     }
 }

--- a/src/Infrastructure/Integrations/Storage/StorageService.cs
+++ b/src/Infrastructure/Integrations/Storage/StorageService.cs
@@ -6,7 +6,6 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 
-using Amazon;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Amazon.S3.Transfer;
@@ -23,20 +22,24 @@ public class StorageService : IStorageService
 {
     private const string ProjectPreffix = "bt-cm";
     private readonly ILogger logger;
-    private readonly AmazonS3Client client;
-    private readonly string bucketName;
+    private readonly IAmazonS3 client;
     private readonly string endpointUrl;
+    private readonly string bucketName;
 
     /// <summary>
     /// Constructor.
     /// </summary>
     /// <param name="logger">Logger.</param>
-    public StorageService(ILogger logger)
+    /// <param name="client">AWS S3 client.</param>
+    public StorageService(
+        ILogger logger,
+        IAmazonS3 client)
     {
         this.logger = logger;
-        bucketName = Environment.GetEnvironmentVariable("S3_BUCKET_NAME");
+        this.client = client;
+
         endpointUrl = Environment.GetEnvironmentVariable("S3_ENDPOINT_URL");
-        client = InitClient();
+        bucketName = Environment.GetEnvironmentVariable("S3_BUCKET_NAME");
     }
 
     /// <inheritdoc/>
@@ -157,25 +160,5 @@ public class StorageService : IStorageService
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Initialize AWS client.
-    /// </summary>
-    /// <returns>AWS client.</returns>
-    private static AmazonS3Client InitClient()
-    {
-        var accessKey = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY");
-        var secretkey = Environment.GetEnvironmentVariable("AWS_SECRET_KEY");
-
-        var config = new AmazonS3Config
-        {
-            RegionEndpoint = RegionEndpoint.GetBySystemName(Environment.GetEnvironmentVariable("AWS_REGION")),
-            ServiceURL = Environment.GetEnvironmentVariable("S3_ENDPOINT_URL"),
-            UseHttp = true,
-            ForcePathStyle = true,
-        };
-
-        return new(accessKey, secretkey, config);
     }
 }

--- a/src/Infrastructure/Persistence/Config/DependencyRegistry/ConfigDbDependencies.cs
+++ b/src/Infrastructure/Persistence/Config/DependencyRegistry/ConfigDbDependencies.cs
@@ -1,7 +1,5 @@
 ﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.DependencyRegistry;
 
-using System;
-
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 
 using Microsoft.EntityFrameworkCore;
@@ -12,13 +10,12 @@ using Microsoft.Extensions.DependencyInjection;
 /// </summary>
 public static class ConfigDbDependencies
 {
-    private static readonly string ConnectionString = Environment.GetEnvironmentVariable("CS_MAIN");
-
     /// <summary>
     /// Add database services.
     /// </summary>
     /// <param name="services">Application services.</param>
-    public static void AddDbServices(IServiceCollection services) =>
+    /// <param name="connectionString">Database connection string.</param>
+    public static void AddDbServices(IServiceCollection services, string connectionString) =>
         services.AddDbContext<GeneralContext>(c =>
-            c.UseNpgsql(ConnectionString, npgsqlOptions => npgsqlOptions.UseNetTopologySuite()));
+            c.UseNpgsql(connectionString, npgsqlOptions => npgsqlOptions.UseNetTopologySuite()));
 }

--- a/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
@@ -20,6 +20,7 @@ using IAVH.BioTablero.CM.WebApi.Services;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 
 /// <summary>
@@ -116,16 +117,19 @@ public static class ConfigCoreDependencies
         services.AddHealthChecks()
             .AddOpenIdConnectServer(
                 oidcSvrUri: new Uri(OidcServer),
-                name: "keycloak")
+                name: "keycloak",
+                tags: ["ready"])
             .AddNpgSql(
                 ConnectionString,
-                name: "postgres")
+                name: "postgres",
+                tags: ["ready"])
             .AddTcpHealthCheck(
                 setup: options =>
                 {
                     options.AddHost("1.1.1.1", 53);
                 },
-                name: "internet")
+                name: "internet",
+                tags: ["ready"])
             .AddSmtpHealthCheck(
                 options =>
                 {
@@ -140,8 +144,15 @@ public static class ConfigCoreDependencies
                         options.LoginWith(SmtpData.User, SmtpData.Password);
                     }
                 },
-                name: "smtp")
-            .AddCheck<S3HealthCheck>(name: "aws s3");
+                name: "smtp",
+                tags: ["ready"])
+            .AddCheck<S3HealthCheck>(
+                name: "aws s3",
+                tags: ["ready"])
+            .AddCheck(
+                "self",
+                () => HealthCheckResult.Healthy(),
+                tags: ["live"]);
 
         return services;
     }

--- a/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
@@ -43,7 +43,8 @@ public static class ConfigCoreDependencies
                 name: "keycloak")
             .AddNpgSql(
                 ConnectionString,
-                name: "postgres");
+                name: "postgres")
+            .AddCheck<S3HealthCheck>(name: "aws s3");
 
         services.AddHttpContextAccessor(); // Required for Serilog (ASP.NET)
 

--- a/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
@@ -21,6 +21,8 @@ using Microsoft.IdentityModel.Tokens;
 /// </summary>
 public static class ConfigCoreDependencies
 {
+    private static readonly string OidcServer = $"{Environment.GetEnvironmentVariable("KC_BASE_URL")}/realms/{Environment.GetEnvironmentVariable("KC_REALM")}/";
+
     /// <summary>
     /// Add core services.
     /// </summary>
@@ -29,7 +31,11 @@ public static class ConfigCoreDependencies
     /// <returns>Service descriptors collection with custom services.</returns>
     public static IServiceCollection AddCoreServices(this IServiceCollection services, bool isDevelopment = false)
     {
-        services.AddHealthChecks();
+        services.AddHealthChecks()
+            .AddOpenIdConnectServer(
+                oidcSvrUri: new Uri(OidcServer),
+                name: "keycloak");
+
         services.AddHttpContextAccessor(); // Required for Serilog (ASP.NET)
 
         // Enabled MVC without routing
@@ -59,20 +65,19 @@ public static class ConfigCoreDependencies
     /// <returns>Service descriptors collection with authentication service.</returns>
     private static IServiceCollection AddAuthService(this IServiceCollection services, bool isDevelopment)
     {
-        var url = $"{Environment.GetEnvironmentVariable("KC_BASE_URL")}/realms/{Environment.GetEnvironmentVariable("KC_REALM")}";
         var clientId = Environment.GetEnvironmentVariable("KC_CLIENT");
 
         services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
             {
-                options.Authority = url;
+                options.Authority = OidcServer;
                 options.Audience = clientId;
                 options.TokenValidationParameters = new TokenValidationParameters
                 {
                     ValidateAudience = true,
                     ValidateIssuer = true,
-                    ValidIssuer = url,
+                    ValidIssuer = OidcServer,
                     ValidateLifetime = true,
                 };
                 options.RequireHttpsMetadata = !isDevelopment;

--- a/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
@@ -8,6 +8,7 @@ using IAVH.BioTablero.CM.Application.Services.General;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Config.DependencyRegistry;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories;
+using IAVH.BioTablero.CM.WebApi.Config.HealthChecks;
 using IAVH.BioTablero.CM.WebApi.Controllers.Tools;
 using IAVH.BioTablero.CM.WebApi.Interfaces;
 using IAVH.BioTablero.CM.WebApi.Services;
@@ -36,15 +37,7 @@ public static class ConfigCoreDependencies
         // Add DB Contexts
         ConfigDbDependencies.AddDbServices(services, ConnectionString);
 
-        // Health checks setup
-        services.AddHealthChecks()
-            .AddOpenIdConnectServer(
-                oidcSvrUri: new Uri(OidcServer),
-                name: "keycloak")
-            .AddNpgSql(
-                ConnectionString,
-                name: "postgres")
-            .AddCheck<S3HealthCheck>(name: "aws s3");
+        services.ConfigureHealthChecks();
 
         services.AddHttpContextAccessor(); // Required for Serilog (ASP.NET)
 
@@ -107,4 +100,23 @@ public static class ConfigCoreDependencies
         {
             options.MultipartBodyLengthLimit = 5_242_880; // 5 MB
         });
+
+    /// <summary>
+    /// Configure HealthChecks.
+    /// </summary>
+    /// <param name="services">Service descriptors collection.</param>
+    /// <returns>Service descriptors collection with custom services.</returns>
+    private static IServiceCollection ConfigureHealthChecks(this IServiceCollection services)
+    {
+        services.AddHealthChecks()
+            .AddOpenIdConnectServer(
+                oidcSvrUri: new Uri(OidcServer),
+                name: "keycloak")
+            .AddNpgSql(
+                ConnectionString,
+                name: "postgres")
+            .AddCheck<S3HealthCheck>(name: "aws s3");
+
+        return services;
+    }
 }

--- a/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
@@ -2,10 +2,14 @@
 
 using System;
 
+using global::HealthChecks.Network.Core;
+
 using IAVH.BioTablero.CM.Application.Interfaces.General;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.General;
 using IAVH.BioTablero.CM.Application.Services.General;
+using IAVH.BioTablero.CM.Core.Domain.Models.Email;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories;
+using IAVH.BioTablero.CM.Infrastructure.Integrations.Email;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Config.DependencyRegistry;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories;
 using IAVH.BioTablero.CM.WebApi.Config.HealthChecks;
@@ -25,6 +29,7 @@ public static class ConfigCoreDependencies
 {
     private static readonly string OidcServer = $"{Environment.GetEnvironmentVariable("KC_BASE_URL")}/realms/{Environment.GetEnvironmentVariable("KC_REALM")}/";
     private static readonly string ConnectionString = Environment.GetEnvironmentVariable("CS_MAIN");
+    private static readonly SmtpConfigData SmtpData = EmailService.InitSmtpData();
 
     /// <summary>
     /// Add core services.
@@ -115,6 +120,27 @@ public static class ConfigCoreDependencies
             .AddNpgSql(
                 ConnectionString,
                 name: "postgres")
+            .AddTcpHealthCheck(
+                setup: options =>
+                {
+                    options.AddHost("1.1.1.1", 53);
+                },
+                name: "internet")
+            .AddSmtpHealthCheck(
+                options =>
+                {
+                    options.Host = SmtpData.Host;
+                    options.Port = SmtpData.Port;
+                    options.ConnectionType = SmtpData.EnableSsl
+                        ? SmtpConnectionType.TLS
+                        : SmtpConnectionType.PLAIN;
+
+                    if (!string.IsNullOrEmpty(SmtpData.User))
+                    {
+                        options.LoginWith(SmtpData.User, SmtpData.Password);
+                    }
+                },
+                name: "smtp")
             .AddCheck<S3HealthCheck>(name: "aws s3");
 
         return services;

--- a/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
@@ -6,6 +6,7 @@ using IAVH.BioTablero.CM.Application.Interfaces.General;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.General;
 using IAVH.BioTablero.CM.Application.Services.General;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories;
+using IAVH.BioTablero.CM.Infrastructure.Persistence.Config.DependencyRegistry;
 using IAVH.BioTablero.CM.Infrastructure.Persistence.Repositories;
 using IAVH.BioTablero.CM.WebApi.Controllers.Tools;
 using IAVH.BioTablero.CM.WebApi.Interfaces;
@@ -22,6 +23,7 @@ using Microsoft.IdentityModel.Tokens;
 public static class ConfigCoreDependencies
 {
     private static readonly string OidcServer = $"{Environment.GetEnvironmentVariable("KC_BASE_URL")}/realms/{Environment.GetEnvironmentVariable("KC_REALM")}/";
+    private static readonly string ConnectionString = Environment.GetEnvironmentVariable("CS_MAIN");
 
     /// <summary>
     /// Add core services.
@@ -31,10 +33,17 @@ public static class ConfigCoreDependencies
     /// <returns>Service descriptors collection with custom services.</returns>
     public static IServiceCollection AddCoreServices(this IServiceCollection services, bool isDevelopment = false)
     {
+        // Add DB Contexts
+        ConfigDbDependencies.AddDbServices(services, ConnectionString);
+
+        // Health checks setup
         services.AddHealthChecks()
             .AddOpenIdConnectServer(
                 oidcSvrUri: new Uri(OidcServer),
-                name: "keycloak");
+                name: "keycloak")
+            .AddNpgSql(
+                ConnectionString,
+                name: "postgres");
 
         services.AddHttpContextAccessor(); // Required for Serilog (ASP.NET)
 

--- a/src/WebApi/Config/DependencyRegistry/ConfigExternalServices.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigExternalServices.cs
@@ -92,23 +92,20 @@ public static class ConfigExternalServices
             var region = Environment.GetEnvironmentVariable("AWS_REGION");
             var endpoint = Environment.GetEnvironmentVariable("S3_ENDPOINT_URL");
 
-            var isProductionEnv = endpoint == null;
-            AmazonS3Config config = null;
+            var config = new AmazonS3Config()
+            {
+                RegionEndpoint = RegionEndpoint.GetBySystemName(region),
+            };
 
-            if (isProductionEnv)
+            if (endpoint != null)
             {
                 config = new()
                 {
-                    RegionEndpoint = RegionEndpoint.GetBySystemName(region),
+                    ServiceURL = endpoint,
+                    UseHttp = true,
+                    ForcePathStyle = true,
                 };
             }
-
-            config = new()
-            {
-                ServiceURL = endpoint,
-                UseHttp = true,
-                ForcePathStyle = true,
-            };
 
             return new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey), config);
         });

--- a/src/WebApi/Config/DependencyRegistry/ConfigExternalServices.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigExternalServices.cs
@@ -92,9 +92,19 @@ public static class ConfigExternalServices
             var region = Environment.GetEnvironmentVariable("AWS_REGION");
             var endpoint = Environment.GetEnvironmentVariable("S3_ENDPOINT_URL");
 
-            var config = new AmazonS3Config
+            var isProductionEnv = endpoint == null;
+            AmazonS3Config config = null;
+
+            if (isProductionEnv)
             {
-                RegionEndpoint = RegionEndpoint.GetBySystemName(region),
+                config = new()
+                {
+                    RegionEndpoint = RegionEndpoint.GetBySystemName(region),
+                };
+            }
+
+            config = new()
+            {
                 ServiceURL = endpoint,
                 UseHttp = true,
                 ForcePathStyle = true,

--- a/src/WebApi/Config/DependencyRegistry/ConfigExternalServices.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigExternalServices.cs
@@ -1,5 +1,11 @@
 ﻿namespace IAVH.BioTablero.CM.WebApi.Config.DependencyRegistry;
 
+using System;
+
+using Amazon;
+using Amazon.Runtime;
+using Amazon.S3;
+
 using IAVH.BioTablero.CM.Application.DTOs.Logging;
 using IAVH.BioTablero.CM.Application.Interfaces.ExternalServices;
 using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Initiatives;
@@ -79,6 +85,23 @@ public static class ConfigExternalServices
         services.AddScoped<IVideoHelperService, VideoHelperService>();
         services.AddScoped<IImageUtilsService, ImageUtilsService>();
         services.AddScoped<IWebHelperService, WebHelperService>();
+        services.AddSingleton<IAmazonS3>(_ =>
+        {
+            var accessKey = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY");
+            var secretKey = Environment.GetEnvironmentVariable("AWS_SECRET_KEY");
+            var region = Environment.GetEnvironmentVariable("AWS_REGION");
+            var endpoint = Environment.GetEnvironmentVariable("S3_ENDPOINT_URL");
+
+            var config = new AmazonS3Config
+            {
+                RegionEndpoint = RegionEndpoint.GetBySystemName(region),
+                ServiceURL = endpoint,
+                UseHttp = true,
+                ForcePathStyle = true,
+            };
+
+            return new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey), config);
+        });
 
         return services;
     }

--- a/src/WebApi/Config/DependencyRegistry/S3HealthCheck.cs
+++ b/src/WebApi/Config/DependencyRegistry/S3HealthCheck.cs
@@ -1,0 +1,51 @@
+﻿namespace IAVH.BioTablero.CM.WebApi.Config.DependencyRegistry;
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Amazon.S3;
+using Amazon.S3.Model;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// Custom AWS S3 Healht check.
+/// </summary>
+public class S3HealthCheck : IHealthCheck
+{
+    private readonly IAmazonS3 client;
+    private readonly string bucketName = Environment.GetEnvironmentVariable("S3_BUCKET_NAME");
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="client">AWS S3 client.</param>
+    public S3HealthCheck(IAmazonS3 client)
+    {
+        this.client = client;
+    }
+
+    /// <inheritdoc/>
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await client.ListObjectsV2Async(
+                new ListObjectsV2Request
+                {
+                    BucketName = bucketName,
+                    MaxKeys = 1,
+                },
+                cancellationToken);
+
+            return HealthCheckResult.Healthy("S3 reachable");
+        }
+        catch (AmazonS3Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("S3 unavailable", ex);
+        }
+    }
+}

--- a/src/WebApi/Config/DependencyRegistry/S3HealthCheck.cs
+++ b/src/WebApi/Config/DependencyRegistry/S3HealthCheck.cs
@@ -12,19 +12,11 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 /// <summary>
 /// Custom AWS S3 Healht check.
 /// </summary>
-public class S3HealthCheck : IHealthCheck
+/// <param name="client">AWS S3 client.</param>
+public class S3HealthCheck(IAmazonS3 client) : IHealthCheck
 {
-    private readonly IAmazonS3 client;
+    private readonly IAmazonS3 client = client;
     private readonly string bucketName = Environment.GetEnvironmentVariable("S3_BUCKET_NAME");
-
-    /// <summary>
-    /// Constructor.
-    /// </summary>
-    /// <param name="client">AWS S3 client.</param>
-    public S3HealthCheck(IAmazonS3 client)
-    {
-        this.client = client;
-    }
 
     /// <inheritdoc/>
     public async Task<HealthCheckResult> CheckHealthAsync(
@@ -33,19 +25,18 @@ public class S3HealthCheck : IHealthCheck
     {
         try
         {
-            await client.ListObjectsV2Async(
-                new ListObjectsV2Request
-                {
-                    BucketName = bucketName,
-                    MaxKeys = 1,
-                },
-                cancellationToken);
+            var request = new HeadBucketRequest
+            {
+                BucketName = bucketName,
+            };
 
-            return HealthCheckResult.Healthy("S3 reachable");
+            await client.HeadBucketAsync(request, cancellationToken);
+
+            return HealthCheckResult.Healthy();
         }
         catch (AmazonS3Exception ex)
         {
-            return HealthCheckResult.Unhealthy("S3 unavailable", ex);
+            return HealthCheckResult.Unhealthy("S3 bucket unavailable", ex);
         }
     }
 }

--- a/src/WebApi/Config/HealthChecks/S3HealthCheck.cs
+++ b/src/WebApi/Config/HealthChecks/S3HealthCheck.cs
@@ -1,4 +1,4 @@
-﻿namespace IAVH.BioTablero.CM.WebApi.Config.DependencyRegistry;
+﻿namespace IAVH.BioTablero.CM.WebApi.Config.HealthChecks;
 
 using System;
 using System.Threading;

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -4,7 +4,6 @@ using System.Text.Json.Serialization;
 
 using DotNetEnv;
 
-using IAVH.BioTablero.CM.Infrastructure.Persistence.Config.DependencyRegistry;
 using IAVH.BioTablero.CM.WebApi.Config.DependencyRegistry;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup;
 using IAVH.BioTablero.CM.WebApi.Config.LoggerSetup;
@@ -34,10 +33,7 @@ public class Program
         // Load environment variables from a local file
         Env.Load("../../.env");
 
-        // Add DB Contexts
-        ConfigDbDependencies.AddDbServices(builder.Services);
-
-        // Dependency injection configuration
+        // Dependency registry setup
         builder.Services.AddHttpClient();
         builder.Services.AddCoreServices(builder.Environment.IsDevelopment());
         builder.Services.AddAppServices();

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -7,6 +7,7 @@ using DotNetEnv;
 using IAVH.BioTablero.CM.WebApi.Config.DependencyRegistry;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup;
 using IAVH.BioTablero.CM.WebApi.Config.LoggerSetup;
+using IAVH.BioTablero.CM.WebApi.Utils;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -93,11 +94,13 @@ public class Program
         app.MapHealthChecks("/health/live", new HealthCheckOptions
         {
             Predicate = r => r.Tags.Contains("live"),
+            ResponseWriter = HealthCheckResponseWriter.ResponseWriter,
         });
 
         app.MapHealthChecks("/health/ready", new HealthCheckOptions
         {
             Predicate = r => r.Tags.Contains("ready"),
+            ResponseWriter = HealthCheckResponseWriter.ResponseWriter,
         });
 
         // Add support to logging request with Serilog

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -9,6 +9,7 @@ using IAVH.BioTablero.CM.WebApi.Config.DocsSetup;
 using IAVH.BioTablero.CM.WebApi.Config.LoggerSetup;
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.OData;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -89,7 +90,15 @@ public class Program
         }
 
         // Setup health checks endpoint
-        app.MapHealthChecks("/health");
+        app.MapHealthChecks("/health/live", new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("live"),
+        });
+
+        app.MapHealthChecks("/health/ready", new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains("ready"),
+        });
 
         // Add support to logging request with Serilog
         app.UseSerilogRequestLogging();

--- a/src/WebApi/Utils/HealthCheckResponseWriter.cs
+++ b/src/WebApi/Utils/HealthCheckResponseWriter.cs
@@ -1,0 +1,39 @@
+﻿namespace IAVH.BioTablero.CM.WebApi.Utils;
+
+using System;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+/// <summary>
+/// Custom health check response writer.
+/// </summary>
+public static class HealthCheckResponseWriter
+{
+    /// <summary>
+    /// Response writer function.
+    /// </summary>
+    public static readonly Func<HttpContext, HealthReport, Task> ResponseWriter =
+        async (context, report) =>
+        {
+            context.Response.ContentType = "application/json";
+
+            var response = new
+            {
+                status = report.Status.ToString(),
+                results = report.Entries.ToDictionary(
+                    e => e.Key,
+                    e => e.Value.Status.ToString()),
+            };
+
+            await context.Response.WriteAsync(JsonSerializer.Serialize(response, JsonOptions));
+        };
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+}

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.OpenIdConnectServer" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Npgsql" Version="9.0.0" />
     <PackageReference Include="Cronos" Version="0.11.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.OpenIdConnectServer" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Npgsql" Version="9.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Network" Version="9.0.0" />
     <PackageReference Include="Cronos" Version="0.11.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />

--- a/src/WebApi/WebApi.csproj
+++ b/src/WebApi/WebApi.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.OpenIdConnectServer" Version="9.0.0" />
     <PackageReference Include="Cronos" Version="0.11.0" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />


### PR DESCRIPTION
## 🛠️ Cambios
- Agregados 2 endpoints de salud mejorados. Ahora pueden analizar problemas en la base de datos, con el bucket S3, con el servidor SMTP, con el sistema de usuarios y con la conexión a internet.
- Mejoras en los servicios de almacenamiento y correo electrónico

## 📝 Tareas asociadas
Resuelve lib-523

## 🤔 Consideraciones
- Ahora existen 2 endpoints de salud:
  - `health/live` Solo indica si el sistema está desplegado
  - `health/ready` Indica si el sistema tiene buena salud, e indica con detalle la salud de cada sistema externo
  - Para validar los servicios de salud, se pueden detener uno a uno los contenedores de docker y consumirlos para ver las diferentes respuestas. Una respuesta exitosa tendrá el código 200 y una fallida tendrá el código 503
  
Ejemplo de respuesta:

```json
{
  "status": "Healthy",
  "results": {
    "keycloak": "Healthy",
    "postgres": "Healthy",
    "internet": "Healthy",
    "smtp": "Healthy",
    "aws s3": "Healthy"
  }
}
```

## ✅ Verificaciones
- No aplica.