### PR TITLE
Ajustes varios

### DIFF
--- a/src/Application/Services/Initiatives/InitiativeTagService.cs
+++ b/src/Application/Services/Initiatives/InitiativeTagService.cs
@@ -164,8 +164,9 @@ public class InitiativeTagService : IInitiativeTagService
         }
 
         await entityRepository.DeleteAsync(entity, ct);
+        var entityData = mapper.Map(entity);
 
-        logger.AddLog(LogType.Delete, "Deleted initiative tag relationship", "{@EntityData}", entity);
+        logger.AddLog(LogType.Delete, "Deleted initiative tag relationship", "{@EntityData}", entityData);
 
         return new();
     }

--- a/src/Application/Services/Tag/TagService.cs
+++ b/src/Application/Services/Tag/TagService.cs
@@ -137,7 +137,7 @@ public class TagService : ServiceRead<Tag, TagDto, int>, ITagService
         {
             return new(true)
             {
-                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Resources.Duplicated),
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.Tags.Duplicated),
             };
         }
 

--- a/src/Application/Services/TerritoryStories/TerritoryStoryService.cs
+++ b/src/Application/Services/TerritoryStories/TerritoryStoryService.cs
@@ -154,7 +154,8 @@ public class TerritoryStoryService : ServiceRead<TerritoryStory, TerritoryStoryD
     {
         // Validate user permissions
         var initiativeId = entityData?.InitiativeId ?? 0;
-        var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(initiativeId, entityData.AuthorUserName, (int)InitiativeUserLevelEnum.Leader, ct);
+        var authorizedLevels = new int[] { (int)InitiativeUserLevelEnum.Leader, (int)InitiativeUserLevelEnum.Member };
+        var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelsAsync(initiativeId, entityData.AuthorUserName, authorizedLevels, ct);
 
         if (!authorizedUserAction)
         {

--- a/src/Application/Services/TerritoryStories/TerritoryStoryVideoService.cs
+++ b/src/Application/Services/TerritoryStories/TerritoryStoryVideoService.cs
@@ -146,7 +146,7 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
         }
 
         // Validate duplicated entities
-        var hasDuplicatedEntities = await entityRepository.IsDuplicatedAsync(new Uri(entityData.FileUrl), ct);
+        var hasDuplicatedEntities = await entityRepository.IsDuplicatedAsync(territoryStoryId, new Uri(entityData.FileUrl), ct);
 
         if (hasDuplicatedEntities)
         {
@@ -231,7 +231,7 @@ public class TerritoryStoryVideoService : ServiceRead<TerritoryStoryVideo, Terri
         }
 
         // Validate duplicated entities
-        var hasDuplicatedEntities = await entityRepository.IsDuplicatedAsync(id, new Uri(entityData.FileUrl), ct);
+        var hasDuplicatedEntities = await entityRepository.IsDuplicatedAsync(id, entity.TerritoryStoryId, new Uri(entityData.FileUrl), ct);
 
         if (hasDuplicatedEntities)
         {

--- a/src/Application/Utils/StringUtils.cs
+++ b/src/Application/Utils/StringUtils.cs
@@ -1,5 +1,6 @@
 ﻿namespace IAVH.BioTablero.CM.Application.Utils;
 
+using System;
 using System.Globalization;
 
 /// <summary>
@@ -16,5 +17,21 @@ public static class StringUtils
     {
         var currentCulture = CultureInfo.CurrentCulture;
         return currentCulture.TextInfo.ToTitleCase(input.ToLower(currentCulture));
+    }
+
+    /// <summary>
+    /// Convert first string char to lower case.
+    /// </summary>
+    /// <param name="input">String input.</param>
+    /// <returns>String input with the first char in lower case.</returns>
+    /// <exception cref="ArgumentException">Property argument exception.</exception>
+    public static string LowerCaseFirstChar(this string input)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            throw new ArgumentException("The input must be a non-emtpy string.");
+        }
+
+        return char.ToLowerInvariant(input[0]) + input[1..];
     }
 }

--- a/src/Application/Utils/StringUtils.cs
+++ b/src/Application/Utils/StringUtils.cs
@@ -1,6 +1,5 @@
 ﻿namespace IAVH.BioTablero.CM.Application.Utils;
 
-using System;
 using System.Globalization;
 
 /// <summary>
@@ -24,12 +23,11 @@ public static class StringUtils
     /// </summary>
     /// <param name="input">String input.</param>
     /// <returns>String input with the first char in lower case.</returns>
-    /// <exception cref="ArgumentException">Property argument exception.</exception>
     public static string LowerCaseFirstChar(this string input)
     {
         if (string.IsNullOrEmpty(input))
         {
-            throw new ArgumentException("The input must be a non-emtpy string.");
+            return input;
         }
 
         return char.ToLowerInvariant(input[0]) + input[1..];

--- a/src/Core/Domain/Utils/Constants/RegExprConstants.cs
+++ b/src/Core/Domain/Utils/Constants/RegExprConstants.cs
@@ -31,12 +31,12 @@ public static class RegExprConstants
     /// <example>
     /// Valid keyword list:
     /// - Naturaleza,Colibrí
-    /// - Champiñón,Guanábana,Ñame,Guayaba,Plátano
+    /// - Champiñón,Guanábana,Ñame,Plátano
     /// - COP16,G20
     /// - Yuca
     /// </example>
     /// </summary>
-    public const string Keywords = @"^([A-Z\u00d1ÁÉÍÓÚ]+[a-z0-9\u00f1áéíóú]*(,){1}){0,4}([A-Z\u00d1ÁÉÍÓÚ]+[a-z0-9\u00f1áéíóú]*){1}$";
+    public const string Keywords = @"^([A-Za-z0-9\u00d1ÁÉÍÓÚ\u00f1áéíóú]+(,){1}){0,3}([A-Za-z0-9\u00d1ÁÉÍÓÚ\u00f1áéíóú]+){1}$";
 
     /// <summary>
     /// Regular expression for YouTube video Url.

--- a/src/Core/Interfaces/Repositories/Initiatives/IInitiativeUserRepository.cs
+++ b/src/Core/Interfaces/Repositories/Initiatives/IInitiativeUserRepository.cs
@@ -31,6 +31,16 @@ public interface IInitiativeUserRepository : IRepository<InitiativeUser, int>
     Task<bool> AnyByInitiativeUserAndLevelAsync(int initiativeId, string userName, int? levelId, CancellationToken ct = default);
 
     /// <summary>
+    /// Get elements by initiative, user and level list.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="authorizedLevels">Authorized level identifier list.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Entities by selected initiative.</returns>
+    Task<bool> AnyByInitiativeUserAndLevelsAsync(int initiativeId, string userName, int[] authorizedLevels, CancellationToken ct = default);
+
+    /// <summary>
     /// Get by initiative and username.
     /// </summary>
     /// <param name="initiativeId">Initiative identifier.</param>

--- a/src/Core/Interfaces/Repositories/TerritoryStories/ITerritoryStoryVideoRepository.cs
+++ b/src/Core/Interfaces/Repositories/TerritoryStories/ITerritoryStoryVideoRepository.cs
@@ -41,19 +41,21 @@ public interface ITerritoryStoryVideoRepository : IRepository<TerritoryStoryVide
     /// <summary>
     /// Check if element is duplicated.
     /// </summary>
+    /// <param name="territoryStoryId">Territory Story identifier.</param>
     /// <param name="fileUrl">File URL.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if any element exists. False otherwise.</returns>
-    Task<bool> IsDuplicatedAsync(Uri fileUrl, CancellationToken ct = default);
+    Task<bool> IsDuplicatedAsync(int territoryStoryId, Uri fileUrl, CancellationToken ct = default);
 
     /// <summary>
     /// Check if element is duplicated.
     /// </summary>
     /// <param name="id">Entity identifier.</param>
+    /// <param name="territoryStoryId">Territory Story identifier.</param>
     /// <param name="fileUrl">File URL.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if any element exists. False otherwise.</returns>
-    Task<bool> IsDuplicatedAsync(int id, Uri fileUrl, CancellationToken ct = default);
+    Task<bool> IsDuplicatedAsync(int id, int territoryStoryId, Uri fileUrl, CancellationToken ct = default);
 
     /// <summary>
     /// Check if elements are duplicated.

--- a/src/Infrastructure/Integrations/Iam/IamService.cs
+++ b/src/Infrastructure/Integrations/Iam/IamService.cs
@@ -103,7 +103,7 @@ public class IamService : IIamService
 
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
-        var url = new Uri($"{baseUrlAdmin}/users?enabled=true");
+        var url = new Uri($"{baseUrlAdmin}/users?enabled=true&emailVerified=true");
 
         var response = await httpClient.GetAsync(url, ct);
 

--- a/src/Infrastructure/Persistence/Config/Entities/TerritoryStories/TerritoryStoryVideoConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/TerritoryStories/TerritoryStoryVideoConfig.cs
@@ -35,7 +35,7 @@ public class TerritoryStoryVideoConfig : IEntityTypeConfiguration<TerritoryStory
             .HasForeignKey(e => e.TerritoryStoryId);
 
         builder
-            .HasIndex(e => e.FileUrl)
+            .HasIndex(e => new { e.TerritoryStoryId, e.FileUrl })
             .IsUnique();
     }
 }

--- a/src/Infrastructure/Persistence/Migrations/20260319231852_UpdateTerritoryStoryVideoConstraints.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260319231852_UpdateTerritoryStoryVideoConstraints.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20260319231852_UpdateTerritoryStoryVideoConstraints")]
+    partial class UpdateTerritoryStoryVideoConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260319231852_UpdateTerritoryStoryVideoConstraints.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260319231852_UpdateTerritoryStoryVideoConstraints.cs
@@ -1,0 +1,52 @@
+﻿#nullable disable
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class UpdateTerritoryStoryVideoConstraints : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_territory_story_video_file_url",
+            schema: "initiatives",
+            table: "territory_story_video");
+
+        migrationBuilder.DropIndex(
+            name: "IX_territory_story_video_territory_story_id",
+            schema: "initiatives",
+            table: "territory_story_video");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_territory_story_video_territory_story_id_file_url",
+            schema: "initiatives",
+            table: "territory_story_video",
+            columns: new[] { "territory_story_id", "file_url" },
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_territory_story_video_territory_story_id_file_url",
+            schema: "initiatives",
+            table: "territory_story_video");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_territory_story_video_file_url",
+            schema: "initiatives",
+            table: "territory_story_video",
+            column: "file_url",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_territory_story_video_territory_story_id",
+            schema: "initiatives",
+            table: "territory_story_video",
+            column: "territory_story_id");
+    }
+}

--- a/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
@@ -99,7 +99,7 @@ public class InitiativeRepository : Repository<Initiative, int>, IInitiativeRepo
     public async Task<Point> GetCentroidAsync(int[] locationIds, CancellationToken ct = default)
     {
         var geometries = await dbContext.LocationPolygons
-            .Where(lp => locationIds.Contains(lp.Id))
+            .Where(lp => locationIds.Contains(lp.LocationId))
             .Select(lp => lp.Geometry)
             .ToListAsync(ct);
 

--- a/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeUserRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeUserRepository.cs
@@ -45,6 +45,15 @@ public class InitiativeUserRepository : Repository<InitiativeUser, int>, IInitia
             .AnyAsync(ct);
 
     /// <inheritdoc/>
+    public async Task<bool> AnyByInitiativeUserAndLevelsAsync(int initiativeId, string userName, int[] authorizedLevels, CancellationToken ct = default) =>
+        await dbContext.InitiativeUsers
+            .Where(e =>
+                e.InitiativeId == initiativeId &&
+                e.UserName == userName &&
+                authorizedLevels.Contains(e.LevelId))
+            .AnyAsync(ct);
+
+    /// <inheritdoc/>
     public async Task<InitiativeUser> GetByInitiativeAndUserNameAsync(int initiativeId, string userName, CancellationToken ct = default) =>
         await dbContext.InitiativeUsers
             .Where(e => e.InitiativeId == initiativeId && e.UserName == userName)

--- a/src/Infrastructure/Persistence/Repositories/TerritoryStories/TerritoryStoryVideoRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/TerritoryStories/TerritoryStoryVideoRepository.cs
@@ -82,15 +82,15 @@ public class TerritoryStoryVideoRepository : Repository<TerritoryStoryVideo, int
             .ToListAsync(ct);
 
     /// <inheritdoc/>
-    public async Task<bool> IsDuplicatedAsync(Uri fileUrl, CancellationToken ct = default) =>
+    public async Task<bool> IsDuplicatedAsync(int territoryStoryId, Uri fileUrl, CancellationToken ct = default) =>
         await dbContext.TerritoryStoryVideos
-            .Where(e => e.FileUrl == fileUrl)
+            .Where(e => e.TerritoryStoryId == territoryStoryId && e.FileUrl == fileUrl)
             .AnyAsync(ct);
 
     /// <inheritdoc/>
-    public async Task<bool> IsDuplicatedAsync(int id, Uri fileUrl, CancellationToken ct = default) =>
+    public async Task<bool> IsDuplicatedAsync(int id, int territoryStoryId, Uri fileUrl, CancellationToken ct = default) =>
         await dbContext.TerritoryStoryVideos
-            .Where(e => e.Id != id && e.FileUrl == fileUrl)
+            .Where(e => e.Id != id && e.TerritoryStoryId == territoryStoryId && e.FileUrl == fileUrl)
             .AnyAsync(ct);
 
     /// <inheritdoc/>

--- a/src/WebApi/Resources/ValidationMessages.resx
+++ b/src/WebApi/Resources/ValidationMessages.resx
@@ -342,7 +342,7 @@
     <comment/>
   </data>
   <data name="STO_003" xml:space="preserve">
-    <value>Invalid format. Keywords must be separated by commas. Spaces and special characters are not allowed. Only up to 5 keywords are allowed.</value>
+    <value>Invalid format. Keywords must be separated by commas. Spaces and special characters are not allowed. Only up to 4 keywords are allowed.</value>
     <comment/>
   </data>
   <data name="STO_004" xml:space="preserve">

--- a/src/WebApi/Services/ResxValidationErrorTranslator.cs
+++ b/src/WebApi/Services/ResxValidationErrorTranslator.cs
@@ -8,6 +8,7 @@ using FluentValidation.Results;
 
 using IAVH.BioTablero.CM.Application.Domain;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
+using IAVH.BioTablero.CM.Application.Utils;
 using IAVH.BioTablero.CM.WebApi.Resources;
 
 using Microsoft.Extensions.Localization;
@@ -37,7 +38,7 @@ public class ResxValidationErrorTranslator
             {
                 Code = errorCode,
                 Description = localizer[errorCode],
-                Field = propertyName,
+                Field = propertyName.LowerCaseFirstChar(),
                 Data = data,
             }
         ];
@@ -67,7 +68,7 @@ public class ResxValidationErrorTranslator
             {
                 Code = f.ErrorCode,
                 Description = message,
-                Field = f.PropertyName,
+                Field = f.PropertyName.LowerCaseFirstChar(),
             };
         }
     }


### PR DESCRIPTION
## 🛠️ Cambios
- Correcciones:
  - En el endpoint de usuarios, se han ocultado los que no han confirmado su correo para evitar que aparezcan usuarios internos del cliente del backend de Keycloak
  - Ahora los miembros de una iniciativa pueden crear relatos del territorio
  - Ahora los videos de los relatos son únicos por relato, y no únicos para todo el sistema
  - Ahora se muestra el código de error `TAG_002` en caso de que se intente crear o editar una etiqueta con nombre duplicado
- Ajustes:
  - Ahora los errores que tienen un atributo se generan con camelCase
  - Se ha eliminado la restricción de la primera letra mayúscula en las palabras clave de los relatos del territorio. También se modificó la expresión regular para que admita máximo 4 palabras

## 📝 Tareas asociadas
Resuelve lib-559

## 🤔 Consideraciones
- No mezclar hasta que #35 esté aprobado y cerrado
- Es necesario ejecutar las migraciones para que las validaciones de videos de los relatos del territorio funcionen correctamente

## ✅ Verificaciones
- No aplica.