### PR TITLE
Ajustes varios

### DIFF
--- a/src/Application/DTOs/Resources/ResourceDto.cs
+++ b/src/Application/DTOs/Resources/ResourceDto.cs
@@ -21,6 +21,11 @@ public class ResourceDto : IDto
     public int? InitiativeId { get; set; }
 
     /// <summary>
+    /// Author User Name identifier.
+    /// </summary>
+    public string AuthorUserName { get; set; }
+
+    /// <summary>
     /// Entity name.
     /// </summary>
     public string Name { get; set; }

--- a/src/Application/Interfaces/Services/Resources/IResourceService.cs
+++ b/src/Application/Interfaces/Services/Resources/IResourceService.cs
@@ -25,14 +25,13 @@ public interface IResourceService : IRead<Resource, int>
     Task<CustomWebResponse> GetItemAsync(int id, string userName, CancellationToken ct = default);
 
     /// <summary>
-    /// Get entities by initiative (OData).
+    /// Get elements list (OData).
     /// </summary>
-    /// <param name="initiativeId">Initiative identifier.</param>
     /// <param name="userName">User name.</param>
     /// <param name="queryOptions">OData query options.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
-    Task<CustomWebResponse> GetByInitiativeAsync(int initiativeId, string userName, ODataQueryOptions<Resource> queryOptions, CancellationToken ct = default);
+    Task<CustomWebResponse> GetListAsync(string userName, ODataQueryOptions<Resource> queryOptions, CancellationToken ct = default);
 
     /// <summary>
     /// Add element.

--- a/src/Application/Interfaces/Services/Resources/IResourceService.cs
+++ b/src/Application/Interfaces/Services/Resources/IResourceService.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.OData.Query;
 /// <summary>
 /// Resource service interface.
 /// </summary>
-public interface IResourceService : IRead<Resource, int>
+public interface IResourceService : IRead<Resource, int>, IAdd<ResourceDto>
 {
     /// <summary>
     /// Get element.
@@ -32,15 +32,6 @@ public interface IResourceService : IRead<Resource, int>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     Task<CustomWebResponse> GetListAsync(string userName, ODataQueryOptions<Resource> queryOptions, CancellationToken ct = default);
-
-    /// <summary>
-    /// Add element.
-    /// </summary>
-    /// <param name="userName">User name.</param>
-    /// <param name="entityData">Entity data.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>Process result.</returns>
-    Task<CustomWebResponse> AddAsync(string userName, ResourceDto entityData, CancellationToken ct = default);
 
     /// <summary>
     /// Update element.

--- a/src/Application/Mappings/Initiatives/InitiativeMappings.cs
+++ b/src/Application/Mappings/Initiatives/InitiativeMappings.cs
@@ -33,7 +33,7 @@ public class InitiativeMappings(
             ImageUrl = entity.ImageUrl,
             BannerUrl = entity.BannerUrl,
             Enabled = entity.Enabled,
-            Coordinate = [entity.Coordinate.X, entity.Coordinate.Y],
+            Coordinate = [entity.Coordinate.Y, entity.Coordinate.X],
             PolygonArea = entity.PolygonArea,
             Contacts = entity.InitiativeContacts?.Select(initiativeContactMappings.Map),
             Locations = entity.InitiativeLocations?.Select(initiativeLocationMappings.Map),

--- a/src/Application/Mappings/Resources/ResourceMappings.cs
+++ b/src/Application/Mappings/Resources/ResourceMappings.cs
@@ -25,6 +25,7 @@ public class ResourceMappings(
         {
             Id = entity.Id,
             InitiativeId = entity.InitiativeId,
+            AuthorUserName = entity.AuthorUserName,
             Name = entity.Name,
             Description = entity.Description,
             CreationDate = entity.CreationDate,
@@ -48,6 +49,7 @@ public class ResourceMappings(
         {
             Id = dto.Id ?? 0,
             InitiativeId = dto.InitiativeId ?? 0,
+            AuthorUserName = dto.AuthorUserName,
             ResourceTypeId = dto.ResourceType.Id ?? 0,
             Name = dto.Name,
             Description = dto.Description,

--- a/src/Application/Services/Initiatives/InitiativeService.cs
+++ b/src/Application/Services/Initiatives/InitiativeService.cs
@@ -603,7 +603,7 @@ public class InitiativeService : ServiceRead<Initiative, InitiativeDto, int>, II
         {
             InitiativeId = i.InitiativeId,
             InitiativeName = i.InitiativeName,
-            Coordinate = i.Coordinate,
+            Coordinate = [i.Coordinate[1], i.Coordinate[0]],
         }).ToList();
 
         return new CustomWebResponse

--- a/src/Application/Services/Resources/ResourceService.cs
+++ b/src/Application/Services/Resources/ResourceService.cs
@@ -159,10 +159,10 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> AddAsync(string userName, ResourceDto entityData, CancellationToken ct = default)
+    public async Task<CustomWebResponse> AddAsync(ResourceDto entityData, CancellationToken ct = default)
     {
         // Validate user permissions
-        var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entityData.InitiativeId.Value, userName, null, ct);
+        var authorizedUserAction = await initiativeUserRepository.AnyByInitiativeUserAndLevelAsync(entityData.InitiativeId.Value, entityData.AuthorUserName, null, ct);
 
         if (!authorizedUserAction)
         {

--- a/src/Application/Services/Resources/ResourceService.cs
+++ b/src/Application/Services/Resources/ResourceService.cs
@@ -130,10 +130,10 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
     }
 
     /// <inheritdoc/>
-    public async Task<CustomWebResponse> GetByInitiativeAsync(int initiativeId, string userName, ODataQueryOptions<Resource> queryOptions, CancellationToken ct = default)
+    public async Task<CustomWebResponse> GetListAsync(string userName, ODataQueryOptions<Resource> queryOptions, CancellationToken ct = default)
     {
         var query = entityRepository.GetQueryable();
-        query = await entityRepository.GetQueryWithInitiativeAndUserNameAsync(initiativeId, userName, query, ct);
+        query = entityRepository.GetQueryByUserName(userName, query);
 
         try
         {

--- a/src/Application/Validators/TerritoryStories/TerritoryStoryValidator.cs
+++ b/src/Application/Validators/TerritoryStories/TerritoryStoryValidator.cs
@@ -29,7 +29,7 @@ public class TerritoryStoryValidator : AbstractValidator<TerritoryStoryDto>
         RuleFor(dto => dto.Text)
             .NotEmpty()
                 .WithErrorCode(ValidationErrorCodes.General.EmptyProperty)
-            .MaximumLength(2000)
+            .MaximumLength(5000)
                 .WithErrorCode(ValidationErrorCodes.General.InvalidTextLength);
 
         RuleFor(dto => dto.Restricted)

--- a/src/Core/Domain/Entities/Resources/Resource.cs
+++ b/src/Core/Domain/Entities/Resources/Resource.cs
@@ -18,6 +18,11 @@ public class Resource : BaseEntity<int>, IAggregateRoot
     public int InitiativeId { get; set; }
 
     /// <summary>
+    /// Author User Name identifier.
+    /// </summary>
+    public string AuthorUserName { get; set; }
+
+    /// <summary>
     /// Resource Type identifier.
     /// </summary>
     public int ResourceTypeId { get; set; }

--- a/src/Core/Interfaces/Repositories/Resources/IResourceRepository.cs
+++ b/src/Core/Interfaces/Repositories/Resources/IResourceRepository.cs
@@ -12,14 +12,12 @@ using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
 public interface IResourceRepository : IRepository<Resource, int>
 {
     /// <summary>
-    /// Get query with initiative and user name filters.
+    /// Get query with user name filter.
     /// </summary>
-    /// <param name="initiativeId">Initiative identifier.</param>
     /// <param name="userName">User name.</param>
     /// <param name="query">Linq Query.</param>
-    /// <param name="ct">Cancellation token.</param>
     /// <returns>Custom query.</returns>
-    Task<IQueryable<Resource>> GetQueryWithInitiativeAndUserNameAsync(int initiativeId, string userName, IQueryable<Resource> query, CancellationToken ct = default);
+    IQueryable<Resource> GetQueryByUserName(string userName, IQueryable<Resource> query);
 
     /// <summary>
     /// Check authorized entity modification.

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AWSSDK.S3" Version="4.0.6.4" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="MailKit" Version="4.13.0" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.18" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.18" />

--- a/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Resources/ResourceConfig.cs
@@ -25,6 +25,11 @@ public class ResourceConfig : IEntityTypeConfiguration<Resource>
             .HasColumnName("initiative_id")
             .IsRequired();
 
+        builder.Property(i => i.AuthorUserName)
+            .HasColumnName("author_user_name")
+            .HasMaxLength(75)
+            .IsRequired();
+
         builder.Property(i => i.ResourceTypeId)
             .HasColumnName("resource_type_id")
             .IsRequired();

--- a/src/Infrastructure/Persistence/Config/Entities/TerritoryStories/TerritoryStoryConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/TerritoryStories/TerritoryStoryConfig.cs
@@ -32,7 +32,7 @@ public class TerritoryStoryConfig : IEntityTypeConfiguration<TerritoryStory>
 
         builder.Property(i => i.Text)
             .HasColumnName("text")
-            .HasMaxLength(2000);
+            .HasMaxLength(5000);
 
         builder.Property(i => i.Keywords)
             .HasColumnName("keywords")

--- a/src/Infrastructure/Persistence/Migrations/20260417171115_UpdateTerritoryStoryTextLength.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260417171115_UpdateTerritoryStoryTextLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20260417171115_UpdateTerritoryStoryTextLength")]
+    partial class UpdateTerritoryStoryTextLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260417171115_UpdateTerritoryStoryTextLength.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260417171115_UpdateTerritoryStoryTextLength.cs
@@ -1,0 +1,35 @@
+﻿#nullable disable
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class UpdateTerritoryStoryTextLength : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder) => migrationBuilder.AlterColumn<string>(
+            name: "text",
+            schema: "initiatives",
+            table: "territory_story",
+            type: "character varying(5000)",
+            maxLength: 5000,
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "character varying(2000)",
+            oldMaxLength: 2000,
+            oldNullable: true);
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder) => migrationBuilder.AlterColumn<string>(
+            name: "text",
+            schema: "initiatives",
+            table: "territory_story",
+            type: "character varying(2000)",
+            maxLength: 2000,
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "character varying(5000)",
+            oldMaxLength: 5000,
+            oldNullable: true);
+}

--- a/src/Infrastructure/Persistence/Migrations/20260421135529_AddResourceAuthor.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260421135529_AddResourceAuthor.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20260421135529_AddResourceAuthor")]
+    partial class AddResourceAuthor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260421135529_AddResourceAuthor.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260421135529_AddResourceAuthor.cs
@@ -1,0 +1,25 @@
+﻿#nullable disable
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class AddResourceAuthor : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder) => migrationBuilder.AddColumn<string>(
+            name: "author_user_name",
+            schema: "initiatives",
+            table: "resource",
+            type: "character varying(75)",
+            maxLength: 75,
+            nullable: false,
+            defaultValue: string.Empty);
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder) => migrationBuilder.DropColumn(
+            name: "author_user_name",
+            schema: "initiatives",
+            table: "resource");
+}

--- a/src/Infrastructure/Persistence/Repositories/Resources/ResourceRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Resources/ResourceRepository.cs
@@ -35,21 +35,11 @@ public class ResourceRepository : Repository<Resource, int>, IResourceRepository
             .FirstOrDefaultAsync(ct);
 
     /// <inheritdoc/>
-    public async Task<IQueryable<Resource>> GetQueryWithInitiativeAndUserNameAsync(int initiativeId, string userName, IQueryable<Resource> query, CancellationToken ct = default)
-    {
-        var userBelongsToInitiative = await dbContext.InitiativeUsers
-            .Where(e => e.UserName == userName && e.InitiativeId == initiativeId)
-            .AnyAsync(ct);
-
-        if (userBelongsToInitiative)
-        {
-            return IncludeCustomEntities(query)
-                .Where(e => e.InitiativeId == initiativeId);
-        }
-
-        return IncludeCustomEntities(query)
-            .Where(e => e.InitiativeId == initiativeId && !e.IsDraft);
-    }
+    public IQueryable<Resource> GetQueryByUserName(string userName, IQueryable<Resource> query) =>
+        IncludeCustomEntities(query)
+            .Include(e => e.Initiative)
+                .ThenInclude(e => e.InitiativeUsers)
+            .Where(e => !e.IsDraft || e.Initiative.InitiativeUsers.Any(e => e.UserName == userName));
 
     /// <inheritdoc/>
     public async Task<bool> AuthorizedEntityModifyAsync(int id, string userName, CancellationToken ct = default) =>

--- a/src/WebApi/Config/DocsSetup/Examples/Resource/ResourceOdataResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Resource/ResourceOdataResponseExample.cs
@@ -13,6 +13,7 @@ public class ResourceOdataResponseExample : BaseOdataResponseExample<ResourceDto
         {
             Id = 0,
             InitiativeId = 0,
+            AuthorUserName = "example@example.com",
             ResourceType = new()
             {
                 Id = 0,

--- a/src/WebApi/Config/DocsSetup/Examples/Resource/ResourceResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Resource/ResourceResponseExample.cs
@@ -19,6 +19,7 @@ public class ResourceResponseExample : IExamplesProvider<ResourceDto>
     {
         Id = 0,
         InitiativeId = 0,
+        AuthorUserName = "example@example.com",
         ResourceType = new()
         {
             Id = 0,

--- a/src/WebApi/Config/DocsSetup/Examples/TerritoryStory/TerritoryStoryOdataResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/TerritoryStory/TerritoryStoryOdataResponseExample.cs
@@ -13,11 +13,13 @@ public class TerritoryStoryOdataResponseExample : BaseOdataResponseExample<Terri
         {
             Id = 0,
             InitiativeId = 0,
+            AuthorUserName = "example@example.com",
             Title = "Territory Story example",
             Text = "Territory Story text example",
             Restricted = false,
             Enabled = true,
             FeaturedContent = false,
             Likes = 0,
+            ILikedIt = false,
         };
 }

--- a/src/WebApi/Config/DocsSetup/Examples/TerritoryStory/TerritoryStoryResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/TerritoryStory/TerritoryStoryResponseExample.cs
@@ -16,6 +16,7 @@ public class TerritoryStoryResponseExample : IExamplesProvider<TerritoryStoryDto
     {
         Id = 0,
         InitiativeId = 0,
+        AuthorUserName = "example@example.com",
         Title = "Territory Story example",
         Text = "Territory Story text example",
         Keywords = "Champiñón,Guanábana,Ñame",
@@ -23,6 +24,7 @@ public class TerritoryStoryResponseExample : IExamplesProvider<TerritoryStoryDto
         Enabled = true,
         FeaturedContent = false,
         Likes = 0,
+        ILikedIt = false,
         Images =
         [
             new()

--- a/src/WebApi/Controllers/Rest/Resources/ResourceController.cs
+++ b/src/WebApi/Controllers/Rest/Resources/ResourceController.cs
@@ -73,7 +73,8 @@ public class ResourceController(
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(ResourceResponseExample))]
     public async Task<IActionResult> Post([FromBody] ResourceDto requestData, CancellationToken ct)
     {
-        var response = await entityService.AddAsync(HttpContext.GetUserName(), requestData, ct);
+        requestData.AuthorUserName = HttpContext.GetUserName();
+        var response = await entityService.AddAsync(requestData, ct);
         return webTools.CustomResponse(response);
     }
 

--- a/src/WebApi/Controllers/Rest/Resources/ResourceController.cs
+++ b/src/WebApi/Controllers/Rest/Resources/ResourceController.cs
@@ -47,17 +47,16 @@ public class ResourceController(
     }
 
     /// <summary>
-    /// Get entities by Initiative (paginated).
+    /// Get entities (paginated).
     /// </summary>
-    /// <param name="initiativeId">Initiative identifier.</param>
     /// <param name="queryOptions">OData query options.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Entities list from parameters.</returns>
-    [HttpGet("GetByInitiative/{initiativeId}")]
+    [HttpGet]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(ResourceOdataResponseExample))]
-    public async Task<IActionResult> GetOdataListByInitiative(int initiativeId, ODataQueryOptions<Resource> queryOptions, CancellationToken ct)
+    public async Task<IActionResult> GetOdataList(ODataQueryOptions<Resource> queryOptions, CancellationToken ct)
     {
-        var response = await entityService.GetByInitiativeAsync(initiativeId, HttpContext.GetUserName(), queryOptions, ct);
+        var response = await entityService.GetListAsync(HttpContext.GetUserName(), queryOptions, ct);
         return webTools.CustomResponse(response);
     }
 


### PR DESCRIPTION
## 🛠️ Cambios
- Se ha modificado la longitud máxima del texto en relatios del territorio. Antes era de 3000 caracteres, ahora es de 5000.
- En recursos, se ha eliminado el endpoint `Resources/GetByInitiative` y se ha reemplazado por el endpoint `Resources`, con el que se pueden obtener recursos de todo el sistema. En caso de que el usuario esté autenticado, retornará también los borradores de recursos que pertenezcan a sus iniciativas
- En recursos, se ha agregado la columna `AuthorUserName` para especificar el creador del recurso
- Se ha invertido la latitud y longitud en las coordenadas de indicadores, para que funcionen correctamente con Leaflet

## 📝 Tareas asociadas
Resuelve [lib-634](https://linear.app/biodev/issue/LIB-634)

## 🤔 Consideraciones
- Este ticket mencionaba un error con un endpoint de iniciativas, pero no aparece en este PR porque fue solucionado en #40 
- No fusionar hasta que #40 esté aprobado y cerrado
- Es necesario ejecutar las migraciones para aplicar los cambios en la base de datos

## ✅ Verificaciones
- No aplica.