### PR TITLE
Configurar imagen de docker y evento de Github Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,5 +18,6 @@ LICENSE
 # Ignore folders with external data
 .github/
 .sonarqube/
+.idea/
 .vscode/
 docker/

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -20,15 +20,10 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
 
-      - name: Check code format and unused usings
-        run: dotnet format --verify-no-changes --verbosity diagnostic
-        continue-on-error: false
+      - name: Check code format
+        run: dotnet format --verify-no-changes --no-restore
 
-      - name: Build with code analysis (detects unused code)
+      - name: Build with code analysis
         run: |
           echo "🔍 Analyzing code to detect unused elements..."
-          dotnet build --no-incremental \
-            -warnaserror \
-            -p:EnableNETAnalyzers=true \
-            -p:EnforceCodeStyleInBuild=true
-        continue-on-error: false
+          dotnet build --no-incremental --no-restore -warnaserror

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,3 +50,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'develop'
-      - 'cgalvis/lib-649'
   release:
     types: 
       - published
@@ -43,7 +42,6 @@ jobs:
             type=raw,value=latest-dev,enable=${{ github.ref == 'refs/heads/develop' }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
-            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/cgalvis/lib-649' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'develop'
+      - 'cgalvis/lib-649'
   release:
     types: 
       - published

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,52 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - 'develop'
+  release:
+    types: 
+      - published
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: pem-humboldt/biotablero-cm-backend
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest-dev,enable=${{ github.ref == 'refs/heads/develop' }}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,6 +43,7 @@ jobs:
             type=raw,value=latest-dev,enable=${{ github.ref == 'refs/heads/develop' }}
             type=raw,value=latest,enable=${{ github.event_name == 'release' }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
+            type=ref,event=branch,enable=${{ github.ref == 'refs/heads/cgalvis/lib-649' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,35 @@
-ARG VERSION=8.0.411-alpine3.22-amd64
-ARG ASP_VERSION=8.0.17-alpine3.22-amd64
+ARG VERSION=8.0.420-alpine3.23-amd64
+ARG ASP_VERSION=8.0.26-alpine3.23-amd64
 
 # Build stage
 FROM mcr.microsoft.com/dotnet/sdk:$VERSION AS build-env
 
 WORKDIR /app
 
-## Copy all source code
-COPY . .
+## Copy solution and project files
+ADD *.sln .
+ADD Directory.Build.props .
+ADD /src/Application/*.csproj ./src/Application/
+ADD /src/Core/*.csproj ./src/Core/
+ADD /src/Infrastructure/*.csproj ./src/Infrastructure/
+ADD /src/WebApi/*.csproj ./src/WebApi/
 
 ## Restore dependencies
 RUN dotnet restore
 
+## Copy all source code
+COPY . .
+
 ## Build project and check warnings
-RUN dotnet build --no-incremental -warnaserror
+RUN dotnet build \
+  -c Release \
+  --no-incremental \
+  -warnaserror
 
 ## Publish project
 RUN dotnet publish ./src/WebApi/WebApi.csproj \
   -c Release \
+  --no-build \
   --no-restore \
   -o ./output
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV DOTNET_RUNNING_IN_CONTAINER=true \
 EXPOSE 8080
 
 ## Docker health check setup
-HEALTHCHECK --interval=5s --timeout=10s --retries=3 CMD curl --silent --fail http://localhost:8080/health || exit 1
+HEALTHCHECK --interval=30s --timeout=30s --retries=3 CMD curl --silent --fail http://localhost:8080/health/live || exit 1
 
 ## Execute program
 ENTRYPOINT ["dotnet", "WebApi.dll"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Generate a `.env` file with the project parameters. You can generate the file ba
 ### Run containers
 
 ```sh
-docker compose -f docker-compose-dev.yml up
+docker compose -f docker-compose-dev.yml -p cm-local up
 ```
 
 > **Note:** When running this command for the first time, it's recommended to verify that the project bucket was built correctly with the `docker logs bt-cm-localstack` command. If you encounter an execution permission error, run these commands:
@@ -100,5 +100,5 @@ If you need to remove the last generated migration, you can do so with the comma
 # Build image
 docker build -t biotablero-cm:latest .
 # Run temporal container
-docker run -it --rm --env-file .env --name biotablero-cm-back -p 8001:8080 biotablero-cm:latest
+docker run -it --rm --env-file .env --name biotablero-cm-back -p 8001:8080 --network=cm-local_bt-search-network biotablero-cm:latest
 ```

--- a/README.md
+++ b/README.md
@@ -101,5 +101,4 @@ If you need to remove the last generated migration, you can do so with the comma
 docker build -t biotablero-cm-backend:latest .
 # Run temporal container
 docker run -it --rm --env-file .env --name bt-cm-backend -p 8001:8080 --network=cm-local_bt-search-network biotablero-cm-backend:latest
-# Added useless line for check github cache with docker publish pipeline
 ```

--- a/README.md
+++ b/README.md
@@ -100,5 +100,5 @@ If you need to remove the last generated migration, you can do so with the comma
 # Build image
 docker build -t biotablero-cm:latest .
 # Run temporal container
-docker run -it --rm --env-file .env --name biotablero-cm-back biotablero-cm:latest
+docker run -it --rm --env-file .env --name biotablero-cm-back -p 8001:8080 biotablero-cm:latest
 ```

--- a/README.md
+++ b/README.md
@@ -101,4 +101,5 @@ If you need to remove the last generated migration, you can do so with the comma
 docker build -t biotablero-cm-backend:latest .
 # Run temporal container
 docker run -it --rm --env-file .env --name bt-cm-backend -p 8001:8080 --network=cm-local_bt-search-network biotablero-cm-backend:latest
+# Added useless line for check github cache with docker publish pipeline
 ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you need to remove the last generated migration, you can do so with the comma
 
 ```sh
 # Build image
-docker build -t biotablero-cm:latest .
+docker build -t biotablero-cm-backend:latest .
 # Run temporal container
-docker run -it --rm --env-file .env --name biotablero-cm-back -p 8001:8080 --network=cm-local_bt-search-network biotablero-cm:latest
+docker run -it --rm --env-file .env --name bt-cm-backend -p 8001:8080 --network=cm-local_bt-search-network biotablero-cm-backend:latest
 ```

--- a/sample.env
+++ b/sample.env
@@ -4,36 +4,37 @@
 CS_MAIN=Host=localhost;Port=5432;Username=user;Password=password;Database=biotablero;
 
 ## Auth server variables
-KC_BASE_URL="http://localhost:8080"
-KC_REALM="bt-cm"
-KC_CLIENT="bt-mc-client"
-KC_CLIENT_BACKEND="bt-mc-client-backend"
-KC_CLIENT_BACKEND_PASS="BACK3ND-S3CR3T-K3Y"
+KC_BASE_URL=http://localhost:8080
+KC_REALM=bt-cm
+KC_CLIENT=bt-mc-client
+KC_CLIENT_BACKEND=bt-mc-client-backend
+KC_CLIENT_BACKEND_PASS=BACK3ND-S3CR3T-K3Y
+KC_USE_HTTPS=False
 
 ## Database variables
 ### Postgres
-DB_HOST="localhost"
+DB_HOST=localhost
 DB_PORT=5432
-DB_NAME="biotablero"
-DB_USER="user"
-DB_PASSWORD="password"
+DB_NAME=biotablero
+DB_USER=user
+DB_PASSWORD=password
 ### Keycloak
-KC_DB_NAME="keycloak"
-KC_DB_USER="keycloak_user"
-KC_DB_PASS="keycloak_pass"
+KC_DB_NAME=keycloak
+KC_DB_USER=keycloak_user
+KC_DB_PASS=keycloak_pass
 
 ## External services
 ### AWS
-AWS_ACCESS_KEY=""
-AWS_SECRET_KEY=""
-AWS_REGION="us-east-1"
-S3_ENDPOINT_URL="http://localhost:4566"
-S3_BUCKET_NAME="bt-cm-files"
+AWS_ACCESS_KEY=
+AWS_SECRET_KEY=
+AWS_REGION=us-east-1
+S3_ENDPOINT_URL=http://localhost:4566
+S3_BUCKET_NAME=bt-cm-files
 ### SMTP Server
-SMTP_HOST="localhost"
+SMTP_HOST=localhost
 SMTP_PORT=1025
-SMTP_ENABLED_SSL="False"
-SMTP_FROM="comunicaciones@example.com"
-SMTP_FROM_NAME="Comunicaciones IAVH"
-SMTP_USER=""
-SMTP_PASS=""
+SMTP_ENABLED_SSL=False
+SMTP_FROM=comunicaciones@example.com
+SMTP_FROM_NAME=Comunicaciones IAVH
+SMTP_USER=
+SMTP_PASS=

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="AWSSDK.S3" Version="4.0.6.4" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
-    <PackageReference Include="MailKit" Version="4.13.0" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.18" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.18" />

--- a/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
+++ b/src/WebApi/Config/DependencyRegistry/ConfigCoreDependencies.cs
@@ -76,6 +76,12 @@ public static class ConfigCoreDependencies
     {
         var clientId = Environment.GetEnvironmentVariable("KC_CLIENT");
 
+        var useHttpsStr = Environment.GetEnvironmentVariable("KC_USE_HTTPS");
+        if (!bool.TryParse(useHttpsStr, out bool useHttps))
+        {
+            useHttps = !isDevelopment;
+        }
+
         services
             .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
@@ -89,7 +95,7 @@ public static class ConfigCoreDependencies
                     ValidIssuer = OidcServer,
                     ValidateLifetime = true,
                 };
-                options.RequireHttpsMetadata = !isDevelopment;
+                options.RequireHttpsMetadata = useHttps;
             });
 
         return services;


### PR DESCRIPTION
## 🛠️ Cambios
- Se simplificó y mejoró el evento de verificación de código (`.github/workflows/check-code.yml`)
- Se hicieron mejorar y correcciones en el Dockerfile
- Se eliminaron las comillas en los valores del archivo `sample.env` para que Docker las procese correctamente
- Se agregó la nueva variable de entorno `KC_USE_HTTPS` para especificar si los JWTs vienen de una dirección con HTTPS o no
- Se actualizó la biblioteca `MailKit` por una vulnerabilidad que generaba una advertencia y no permitía construir el proyecto de .NET
- Se agregó un evento para construir imágenes de Docker y subirlas a GHCR. Este evento usa la caché de Github, lo que hace que se reutilicen las capas al momento de construir.

## 📝 Tareas asociadas
Resuelve [lib-649](https://linear.app/biodev/issue/LIB-649)

## 🤔 Consideraciones
- La documentación cambió un poco, por lo que recomiendo ver los cambios para desplegar los contenedores de Docker en el ambiente local
- Recomiendo editar el archivo `.env` para que tenga el mismo formato del archivo `sample.env`
- Hice un par de imágenes de prueba con esta rama [aquí](https://github.com/PEM-Humboldt/biotablero-cm-backend/pkgs/container/biotablero-cm-backend) para verificar el correcto funcionamiento de la imagen y de la caché. Estas imágenes se pueden eliminar cuando se cierre este PR.

## ✅ Verificaciones
- No aplica.