### PR TITLE
Corrección de problema al enviar una notificación al editar un recurso

### DIFF
--- a/src/Application/Services/Resources/ResourceService.cs
+++ b/src/Application/Services/Resources/ResourceService.cs
@@ -423,6 +423,7 @@ public class ResourceService : ServiceRead<Resource, ResourceDto, int>, IResourc
                         { "EditorUserName", userName },
                     },
                 },
+                Receiver = userName,
             },
             Receivers = receivers,
             SendToHiddenReceivers = false,


### PR DESCRIPTION
## 🛠️ Cambios
- Se arregló un problema al intentar enviar una notificación cuando un recurso de una iniciativa había sido actualizado. Esto generaba un error 500.

## 📝 Tareas asociadas
Resuelve [lib-680](https://linear.app/biodev/issue/LIB-680)

## 🤔 Consideraciones
En el ticket original había descrito un problema en el que una persona había desplegado el sistema con Docker y le estaban apareciendo errores detallados. Al disparar un error en mi ambiente con Docker no tuve ningún problema, por lo que sospecho que esa persona modificó el código fuente de su máquina para tener errores detallados en cualquier tipo de ambiente.

A lo que me refiero es que si se presenta un error en producción se debe mostrar la menor cantidad de datos a los usuarios, y sí está funcionando correctamente. Este es un error 500 al intentar consumir datos con la base de datos desconectada:

<img width="960" height="534" alt="image" src="https://github.com/user-attachments/assets/f0c78a2a-006a-4097-9826-7c85620e93fe" />


## ✅ Verificaciones
- No aplica.