### PR TITLE
Estructura base de indicadores

### DIFF
--- a/src/Core/Domain/Entities/Geo/Location.cs
+++ b/src/Core/Domain/Entities/Geo/Location.cs
@@ -3,6 +3,7 @@
 using System.Collections.Generic;
 
 using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
@@ -55,4 +56,9 @@ public class Location : BaseEntity<int>, IAggregateRoot
     /// Initiatives relationship.
     /// </summary>
     public ICollection<Initiative> Initiatives { get; set; }
+
+    /// <summary>
+    /// Indicator Locations relationship.
+    /// </summary>
+    public ICollection<IndicatorLocation> IndicatorLocations { get; set; }
 }

--- a/src/Core/Domain/Entities/Indicators/Indicator.cs
+++ b/src/Core/Domain/Entities/Indicators/Indicator.cs
@@ -1,5 +1,7 @@
 ﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
 
+using System.Collections.Generic;
+
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
@@ -27,4 +29,19 @@ public class Indicator : BaseEntity<int>, IAggregateRoot
     /// Indicator Type relationship.
     /// </summary>
     public IndicatorType Type { get; set; }
+
+    /// <summary>
+    /// Indicator Tag relationship.
+    /// </summary>
+    public ICollection<IndicatorTag> IndicatorTags { get; init; }
+
+    /// <summary>
+    /// Indicator Location relationship.
+    /// </summary>
+    public ICollection<IndicatorLocation> IndicatorLocations { get; init; }
+
+    /// <summary>
+    /// Indicator Version relationship.
+    /// </summary>
+    public ICollection<IndicatorVersion> Versions { get; init; }
 }

--- a/src/Core/Domain/Entities/Indicators/Indicator.cs
+++ b/src/Core/Domain/Entities/Indicators/Indicator.cs
@@ -1,12 +1,12 @@
-﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
 
-using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
 /// <summary>
-/// Initiative Tag entity.
+/// Indicator entity.
 /// </summary>
-public class InitiativeTag : BaseEntity<int>, IAggregateRoot
+public class Indicator : BaseEntity<int>, IAggregateRoot
 {
     /// <summary>
     /// Initiative identifier.
@@ -14,9 +14,9 @@ public class InitiativeTag : BaseEntity<int>, IAggregateRoot
     public int InitiativeId { get; set; }
 
     /// <summary>
-    /// Tag identifier.
+    /// Indicator Type identifier.
     /// </summary>
-    public int TagId { get; set; }
+    public int IndicatorTypeId { get; set; }
 
     /// <summary>
     /// Initiative relationship.
@@ -24,7 +24,7 @@ public class InitiativeTag : BaseEntity<int>, IAggregateRoot
     public Initiative Initiative { get; set; }
 
     /// <summary>
-    /// Tag relationship.
+    /// Indicator Type relationship.
     /// </summary>
-    public Tag Tag { get; set; }
+    public IndicatorType Type { get; set; }
 }

--- a/src/Core/Domain/Entities/Indicators/IndicatorLocation.cs
+++ b/src/Core/Domain/Entities/Indicators/IndicatorLocation.cs
@@ -1,0 +1,35 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Geo;
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Indicator Location entity.
+/// </summary>
+public class IndicatorLocation : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Indicator identifier.
+    /// </summary>
+    public int IndicatorId { get; set; }
+
+    /// <summary>
+    /// Location identifier.
+    /// </summary>
+    public int LocationId { get; set; }
+
+    /// <summary>
+    /// Locality name.
+    /// </summary>
+    public string Locality { get; set; }
+
+    /// <summary>
+    /// Indicator relationship.
+    /// </summary>
+    public Indicator Indicator { get; set; }
+
+    /// <summary>
+    /// Location relationship.
+    /// </summary>
+    public Location Location { get; set; }
+}

--- a/src/Core/Domain/Entities/Indicators/IndicatorTag.cs
+++ b/src/Core/Domain/Entities/Indicators/IndicatorTag.cs
@@ -1,17 +1,17 @@
-﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
 
 using IAVH.BioTablero.CM.Core.Domain.Entities.Tags;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
 /// <summary>
-/// Initiative Tag entity.
+/// Indicator Tag entity.
 /// </summary>
-public class InitiativeTag : BaseEntity<int>, IAggregateRoot
+public class IndicatorTag : BaseEntity<int>, IAggregateRoot
 {
     /// <summary>
-    /// Initiative identifier.
+    /// Indicator identifier.
     /// </summary>
-    public int InitiativeId { get; set; }
+    public int IndicatorId { get; set; }
 
     /// <summary>
     /// Tag identifier.
@@ -19,9 +19,9 @@ public class InitiativeTag : BaseEntity<int>, IAggregateRoot
     public int TagId { get; set; }
 
     /// <summary>
-    /// Initiative relationship.
+    /// Indicator relationship.
     /// </summary>
-    public Initiative Initiative { get; set; }
+    public Indicator Indicator { get; set; }
 
     /// <summary>
     /// Tag relationship.

--- a/src/Core/Domain/Entities/Indicators/IndicatorType.cs
+++ b/src/Core/Domain/Entities/Indicators/IndicatorType.cs
@@ -1,5 +1,7 @@
 ﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
 
+using System.Collections.Generic;
+
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
 
 /// <summary>
@@ -11,4 +13,9 @@ public class IndicatorType : BaseEntity<int>, IAggregateRoot
     /// Entity name.
     /// </summary>
     public string Name { get; set; }
+
+    /// <summary>
+    /// Indicator relationship.
+    /// </summary>
+    public ICollection<Indicator> Indicators { get; init; }
 }

--- a/src/Core/Domain/Entities/Indicators/IndicatorType.cs
+++ b/src/Core/Domain/Entities/Indicators/IndicatorType.cs
@@ -1,0 +1,14 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
+
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Indicator Type entity.
+/// </summary>
+public class IndicatorType : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Entity name.
+    /// </summary>
+    public string Name { get; set; }
+}

--- a/src/Core/Domain/Entities/Indicators/IndicatorVersion.cs
+++ b/src/Core/Domain/Entities/Indicators/IndicatorVersion.cs
@@ -1,0 +1,56 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
+
+using System;
+
+using IAVH.BioTablero.CM.Core.Interfaces.Entities;
+
+/// <summary>
+/// Indicator Version entity.
+/// </summary>
+public class IndicatorVersion : BaseEntity<int>, IAggregateRoot
+{
+    /// <summary>
+    /// Indicator identifier.
+    /// </summary>
+    public int IndicatorId { get; set; }
+
+    /// <summary>
+    /// Creation date.
+    /// </summary>
+    public DateTimeOffset CreationDate { get; set; }
+
+    /// <summary>
+    /// Version number.
+    /// </summary>
+    public int Version { get; set; }
+
+    /// <summary>
+    /// Indicator description.
+    /// </summary>
+    public string Description { get; set; }
+
+    /// <summary>
+    /// Indicator methodology.
+    /// </summary>
+    public string Methodology { get; set; }
+
+    /// <summary>
+    /// Indicator interpretation.
+    /// </summary>
+    public string Interpretation { get; set; }
+
+    /// <summary>
+    /// Indicator considerations.
+    /// </summary>
+    public string Considerations { get; set; }
+
+    /// <summary>
+    /// Indicator autorship.
+    /// </summary>
+    public string Authorship { get; set; }
+
+    /// <summary>
+    /// Indicator relationship.
+    /// </summary>
+    public Indicator Indicator { get; set; }
+}

--- a/src/Core/Domain/Entities/Initiatives/Initiative.cs
+++ b/src/Core/Domain/Entities/Initiatives/Initiative.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 
 using IAVH.BioTablero.CM.Core.Domain.Entities;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
 using IAVH.BioTablero.CM.Core.Domain.Entities.TerritoryStories;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
@@ -126,4 +127,9 @@ public class Initiative : BaseEntity<int>, IAggregateRoot
     /// Main location relationship.
     /// </summary>
     public LocationCustom MainLocation { get; set; }
+
+    /// <summary>
+    /// Indicator relationship.
+    /// </summary>
+    public ICollection<Indicator> Indicators { get; init; }
 }

--- a/src/Core/Domain/Entities/Tags/Tag.cs
+++ b/src/Core/Domain/Entities/Tags/Tag.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Resources;
 using IAVH.BioTablero.CM.Core.Interfaces.Entities;
@@ -41,4 +42,9 @@ public class Tag : BaseEntity<int>, IAggregateRoot
     /// Tag Resource relationship.
     /// </summary>
     public ICollection<ResourceTag> TagResources { get; init; }
+
+    /// <summary>
+    /// Tag Indicator relationship.
+    /// </summary>
+    public ICollection<IndicatorTag> TagIndicators { get; init; }
 }

--- a/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorConfig.cs
@@ -35,6 +35,6 @@ public class IndicatorConfig : IEntityTypeConfiguration<Indicator>
 
         builder.HasOne(e => e.Type)
             .WithMany(p => p.Indicators)
-            .HasForeignKey(e => e.InitiativeId);
+            .HasForeignKey(e => e.IndicatorTypeId);
     }
 }

--- a/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorConfig.cs
@@ -1,0 +1,40 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Indicators;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Indicator entity configuration.
+/// </summary>
+public class IndicatorConfig : IEntityTypeConfiguration<Indicator>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<Indicator> builder)
+    {
+        builder.ToTable("indicator", "indicators");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.InitiativeId)
+            .HasColumnName("initiative_id")
+            .IsRequired();
+
+        builder.Property(i => i.IndicatorTypeId)
+            .HasColumnName("indicator_type_id")
+            .IsRequired();
+
+        builder.HasOne(e => e.Initiative)
+            .WithMany(p => p.Indicators)
+            .HasForeignKey(e => e.InitiativeId);
+
+        builder.HasOne(e => e.Type)
+            .WithMany(p => p.Indicators)
+            .HasForeignKey(e => e.InitiativeId);
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorLocationConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorLocationConfig.cs
@@ -1,0 +1,48 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Indicators;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Indicator Location entity configuration.
+/// </summary>
+public class IndicatorLocationConfig : IEntityTypeConfiguration<IndicatorLocation>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<IndicatorLocation> builder)
+    {
+        builder.ToTable("indicator_location", "indicators");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.IndicatorId)
+            .HasColumnName("indicator_id")
+            .IsRequired();
+
+        builder.Property(i => i.LocationId)
+            .HasColumnName("location_id")
+            .IsRequired();
+
+        builder.Property(i => i.Locality)
+            .HasColumnName("locality")
+            .HasMaxLength(300);
+
+        builder.HasOne(e => e.Indicator)
+            .WithMany(p => p.IndicatorLocations)
+            .HasForeignKey(e => e.IndicatorId);
+
+        builder.HasOne(e => e.Location)
+            .WithMany(p => p.IndicatorLocations)
+            .HasForeignKey(e => e.LocationId);
+
+        builder
+            .HasIndex(e => new { e.IndicatorId, e.LocationId, e.Locality })
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorTagConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorTagConfig.cs
@@ -1,0 +1,44 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Indicators;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Indicator Tag entity configuration.
+/// </summary>
+public class IndicatorTagConfig : IEntityTypeConfiguration<IndicatorTag>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<IndicatorTag> builder)
+    {
+        builder.ToTable("indicator_tag", "indicators");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.TagId)
+            .HasColumnName("tag_id")
+            .IsRequired();
+
+        builder.Property(i => i.IndicatorId)
+            .HasColumnName("indicator_id")
+            .IsRequired();
+
+        builder.HasOne(e => e.Tag)
+            .WithMany(p => p.TagIndicators)
+            .HasForeignKey(e => e.TagId);
+
+        builder.HasOne(e => e.Indicator)
+            .WithMany(p => p.IndicatorTags)
+            .HasForeignKey(e => e.IndicatorId);
+
+        builder
+            .HasIndex(e => new { e.IndicatorId, e.TagId })
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorTypeConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorTypeConfig.cs
@@ -1,0 +1,33 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Indicators;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Indicator Type entity configuration.
+/// </summary>
+public class IndicatorTypeConfig : IEntityTypeConfiguration<IndicatorType>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<IndicatorType> builder)
+    {
+        builder.ToTable("indicator_type", "indicators");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.Name)
+            .HasColumnName("name")
+            .HasMaxLength(200)
+            .IsRequired();
+
+        builder
+            .HasIndex(e => e.Name)
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorVersionConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorVersionConfig.cs
@@ -1,0 +1,66 @@
+﻿namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Config.Entities.Indicators;
+
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Indicator Version entity configuration.
+/// </summary>
+public class IndicatorVersionConfig : IEntityTypeConfiguration<IndicatorVersion>
+{
+    /// <inheritdoc/>
+    public void Configure(EntityTypeBuilder<IndicatorVersion> builder)
+    {
+        builder.ToTable("indicator_version", "indicators");
+
+        builder?.HasKey(e => e.Id);
+
+        builder.Property(i => i.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(i => i.IndicatorId)
+            .HasColumnName("indicator_id")
+            .IsRequired();
+
+        builder.Property(e => e.CreationDate)
+            .HasColumnName("creation_date")
+            .HasDefaultValueSql("CURRENT_TIMESTAMP")
+            .IsRequired();
+
+        builder.Property(i => i.Version)
+            .HasColumnName("version")
+            .HasDefaultValue(1)
+            .IsRequired();
+
+        builder.Property(i => i.Description)
+            .HasColumnName("description")
+            .HasMaxLength(1000);
+
+        builder.Property(i => i.Methodology)
+            .HasColumnName("methodology")
+            .HasMaxLength(1000);
+
+        builder.Property(i => i.Interpretation)
+            .HasColumnName("interpretation")
+            .HasMaxLength(1000);
+
+        builder.Property(i => i.Considerations)
+            .HasColumnName("considerations")
+            .HasMaxLength(1000);
+
+        builder.Property(i => i.Authorship)
+            .HasColumnName("authorship")
+            .HasMaxLength(1000);
+
+        builder.HasOne(e => e.Indicator)
+            .WithMany(p => p.Versions)
+            .HasForeignKey(e => e.IndicatorId);
+
+        builder
+            .HasIndex(e => new { e.IndicatorId, e.Version })
+            .IsUnique();
+    }
+}

--- a/src/Infrastructure/Persistence/Config/Entities/Initiatives/InitiativeLocationConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Initiatives/InitiativeLocationConfig.cs
@@ -30,7 +30,8 @@ public class InitiativeLocationConfig : IEntityTypeConfiguration<InitiativeLocat
             .IsRequired();
 
         builder.Property(i => i.Locality)
-            .HasColumnName("locality");
+            .HasColumnName("locality")
+            .HasMaxLength(300);
 
         builder.HasOne(e => e.Initiative)
             .WithMany(p => p.InitiativeLocations)

--- a/src/Infrastructure/Persistence/GeneralContext.cs
+++ b/src/Infrastructure/Persistence/GeneralContext.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 
 using IAVH.BioTablero.CM.Core.Domain.Entities.Geo;
+using IAVH.BioTablero.CM.Core.Domain.Entities.Indicators;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Initiatives;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Logging;
 using IAVH.BioTablero.CM.Core.Domain.Entities.Notifications;
@@ -186,6 +187,35 @@ public sealed class GeneralContext : DbContext
     /// Resource Like DbSet.
     /// </summary>
     public DbSet<ResourceLike> ResourceLikes { get; set; }
+
+    #endregion
+
+    #region Indicator entities
+
+    /// <summary>
+    /// Indicator DbSet.
+    /// </summary>
+    public DbSet<Indicator> Indicators { get; set; }
+
+    /// <summary>
+    /// Indicator Type DbSet.
+    /// </summary>
+    public DbSet<IndicatorType> IndicatorTypes { get; set; }
+
+    /// <summary>
+    /// Indicator Tag DbSet.
+    /// </summary>
+    public DbSet<IndicatorTag> IndicatorTags { get; set; }
+
+    /// <summary>
+    /// Indicator Location DbSet.
+    /// </summary>
+    public DbSet<IndicatorLocation> IndicatorLocations { get; set; }
+
+    /// <summary>
+    /// Indicator Version DbSet.
+    /// </summary>
+    public DbSet<IndicatorVersion> IndicatorVersions { get; set; }
 
     #endregion
 

--- a/src/Infrastructure/Persistence/Migrations/20260519221016_AddIndicatorsBase.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260519221016_AddIndicatorsBase.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20260519221016_AddIndicatorsBase")]
+    partial class AddIndicatorsBase
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260519221016_AddIndicatorsBase.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260519221016_AddIndicatorsBase.Designer.cs
@@ -119,6 +119,8 @@ namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("IndicatorTypeId");
+
                     b.HasIndex("InitiativeId");
 
                     b.ToTable("indicator", "indicators");
@@ -1292,7 +1294,7 @@ namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
                 {
                     b.HasOne("IAVH.BioTablero.CM.Core.Domain.Entities.Indicators.IndicatorType", "Type")
                         .WithMany("Indicators")
-                        .HasForeignKey("InitiativeId")
+                        .HasForeignKey("IndicatorTypeId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 

--- a/src/Infrastructure/Persistence/Migrations/20260519221016_AddIndicatorsBase.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260519221016_AddIndicatorsBase.cs
@@ -56,8 +56,8 @@ public partial class AddIndicatorsBase : Migration
             {
                 table.PrimaryKey("PK_indicator", x => x.id);
                 table.ForeignKey(
-                    name: "FK_indicator_indicator_type_initiative_id",
-                    column: x => x.initiative_id,
+                    name: "FK_indicator_indicator_type_indicator_type_id",
+                    column: x => x.indicator_type_id,
                     principalSchema: "indicators",
                     principalTable: "indicator_type",
                     principalColumn: "id",
@@ -157,6 +157,12 @@ public partial class AddIndicatorsBase : Migration
                     principalColumn: "id",
                     onDelete: ReferentialAction.Cascade);
             });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_indicator_indicator_type_id",
+            schema: "indicators",
+            table: "indicator",
+            column: "indicator_type_id");
 
         migrationBuilder.CreateIndex(
             name: "IX_indicator_initiative_id",

--- a/src/Infrastructure/Persistence/Migrations/20260519221016_AddIndicatorsBase.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260519221016_AddIndicatorsBase.cs
@@ -1,0 +1,242 @@
+﻿#nullable disable
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+/// <inheritdoc />
+public partial class AddIndicatorsBase : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.EnsureSchema(
+            name: "indicators");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "locality",
+            schema: "initiatives",
+            table: "initiative_location",
+            type: "character varying(300)",
+            maxLength: 300,
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "text",
+            oldNullable: true);
+
+        migrationBuilder.CreateTable(
+            name: "indicator_type",
+            schema: "indicators",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                name = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_indicator_type", x => x.id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "indicator",
+            schema: "indicators",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                initiative_id = table.Column<int>(type: "integer", nullable: false),
+                indicator_type_id = table.Column<int>(type: "integer", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_indicator", x => x.id);
+                table.ForeignKey(
+                    name: "FK_indicator_indicator_type_initiative_id",
+                    column: x => x.initiative_id,
+                    principalSchema: "indicators",
+                    principalTable: "indicator_type",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_indicator_initiative_initiative_id",
+                    column: x => x.initiative_id,
+                    principalSchema: "initiatives",
+                    principalTable: "initiative",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "indicator_location",
+            schema: "indicators",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                indicator_id = table.Column<int>(type: "integer", nullable: false),
+                location_id = table.Column<int>(type: "integer", nullable: false),
+                locality = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: true),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_indicator_location", x => x.id);
+                table.ForeignKey(
+                    name: "FK_indicator_location_indicator_indicator_id",
+                    column: x => x.indicator_id,
+                    principalSchema: "indicators",
+                    principalTable: "indicator",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_indicator_location_location_location_id",
+                    column: x => x.location_id,
+                    principalSchema: "geo",
+                    principalTable: "location",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "indicator_tag",
+            schema: "indicators",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                indicator_id = table.Column<int>(type: "integer", nullable: false),
+                tag_id = table.Column<int>(type: "integer", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_indicator_tag", x => x.id);
+                table.ForeignKey(
+                    name: "FK_indicator_tag_indicator_indicator_id",
+                    column: x => x.indicator_id,
+                    principalSchema: "indicators",
+                    principalTable: "indicator",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_indicator_tag_tag_tag_id",
+                    column: x => x.tag_id,
+                    principalSchema: "initiatives",
+                    principalTable: "tag",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "indicator_version",
+            schema: "indicators",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                indicator_id = table.Column<int>(type: "integer", nullable: false),
+                creation_date = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP"),
+                version = table.Column<int>(type: "integer", nullable: false, defaultValue: 1),
+                description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                methodology = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                interpretation = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                considerations = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                authorship = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_indicator_version", x => x.id);
+                table.ForeignKey(
+                    name: "FK_indicator_version_indicator_indicator_id",
+                    column: x => x.indicator_id,
+                    principalSchema: "indicators",
+                    principalTable: "indicator",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_indicator_initiative_id",
+            schema: "indicators",
+            table: "indicator",
+            column: "initiative_id");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_indicator_location_indicator_id_location_id_locality",
+            schema: "indicators",
+            table: "indicator_location",
+            columns: new[] { "indicator_id", "location_id", "locality" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_indicator_location_location_id",
+            schema: "indicators",
+            table: "indicator_location",
+            column: "location_id");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_indicator_tag_indicator_id_tag_id",
+            schema: "indicators",
+            table: "indicator_tag",
+            columns: new[] { "indicator_id", "tag_id" },
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_indicator_tag_tag_id",
+            schema: "indicators",
+            table: "indicator_tag",
+            column: "tag_id");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_indicator_type_name",
+            schema: "indicators",
+            table: "indicator_type",
+            column: "name",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_indicator_version_indicator_id_version",
+            schema: "indicators",
+            table: "indicator_version",
+            columns: new[] { "indicator_id", "version" },
+            unique: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "indicator_location",
+            schema: "indicators");
+
+        migrationBuilder.DropTable(
+            name: "indicator_tag",
+            schema: "indicators");
+
+        migrationBuilder.DropTable(
+            name: "indicator_version",
+            schema: "indicators");
+
+        migrationBuilder.DropTable(
+            name: "indicator",
+            schema: "indicators");
+
+        migrationBuilder.DropTable(
+            name: "indicator_type",
+            schema: "indicators");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "locality",
+            schema: "initiatives",
+            table: "initiative_location",
+            type: "text",
+            nullable: true,
+            oldClrType: typeof(string),
+            oldType: "character varying(300)",
+            oldMaxLength: 300,
+            oldNullable: true);
+    }
+}

--- a/src/Infrastructure/Persistence/Migrations/GeneralContextModelSnapshot.cs
+++ b/src/Infrastructure/Persistence/Migrations/GeneralContextModelSnapshot.cs
@@ -116,6 +116,8 @@ namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 
                     b.HasKey("Id");
 
+                    b.HasIndex("IndicatorTypeId");
+
                     b.HasIndex("InitiativeId");
 
                     b.ToTable("indicator", "indicators");
@@ -1289,7 +1291,7 @@ namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
                 {
                     b.HasOne("IAVH.BioTablero.CM.Core.Domain.Entities.Indicators.IndicatorType", "Type")
                         .WithMany("Indicators")
-                        .HasForeignKey("InitiativeId")
+                        .HasForeignKey("IndicatorTypeId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 


### PR DESCRIPTION
## 🛠️ Cambios
- Se han agregado nuevas entidades base para indicadores, incluyendo la nueva tabla `initiative_tag` para vincular etiquetas de grupos biológicos y ecosistemas.
- Se ha agregado una migración para las entidades anteriores

## 📝 Tareas asociadas
Resuelve [lib-690](https://linear.app/biodev/issue/LIB-690)

## 🤔 Consideraciones
- No fusionar la rama de este PR hasta que #48 esté aprobado y cerrado
- Es necesario reconstruir la base de datos para que se apliquen los cambios
- Al inicio se estaban manejando los indicadores `Probabilidad de detección de la especie en el área de estudio (sin covariables)` y `Probabilidad de ocupación de la especie en el área de estudio (sin covariables)` por separado, pero ya que en los mockups se muestran los dos indicadores en una sola gráfica, he creado un indicador llamado `Probabilidad de detección y ocupación de la especie en el área de estudio (sin covariables)` para utilizar los datos de los dos indicadores en uno

## ✅ Verificaciones
- No aplica.