### PR TITLE
Mi perfil

### DIFF
--- a/src/Application/Interfaces/Services/Initiatives/IInitiativeUserService.cs
+++ b/src/Application/Interfaces/Services/Initiatives/IInitiativeUserService.cs
@@ -41,4 +41,14 @@ public interface IInitiativeUserService : IRead<InitiativeUser, int>, IAdd<Initi
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Process result.</returns>
     Task<CustomWebResponse> DeleteAsync(int id, string userName, bool userIsAdmin, CancellationToken ct = default);
+
+    /// <summary>
+    /// Update focus area.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="userName">User name.</param>
+    /// <param name="entityData">Entity data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> UpdateFocusAreaAsync(int initiativeId, string userName, InitiativeUserDto entityData, CancellationToken ct = default);
 }

--- a/src/Application/Interfaces/Services/Users/IUserService.cs
+++ b/src/Application/Interfaces/Services/Users/IUserService.cs
@@ -14,6 +14,14 @@ using Microsoft.AspNetCore.OData.Query;
 public interface IUserService
 {
     /// <summary>
+    /// Get user profile data.
+    /// </summary>
+    /// <param name="userName">User name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Process result.</returns>
+    Task<CustomWebResponse> GetProfileDataAsync(string userName, CancellationToken ct = default);
+
+    /// <summary>
     /// Get elements list (OData).
     /// </summary>
     /// <param name="queryOptions">OData query options.</param>

--- a/src/Application/Services/Initiatives/InitiativeUserService.cs
+++ b/src/Application/Services/Initiatives/InitiativeUserService.cs
@@ -320,6 +320,33 @@ public class InitiativeUserService : ServiceRead<InitiativeUser, InitiativeUserD
         return new();
     }
 
+    /// <inheritdoc/>
+    public async Task<CustomWebResponse> UpdateFocusAreaAsync(int initiativeId, string userName, InitiativeUserDto entityData, CancellationToken ct = default)
+    {
+        var entity = await entityRepository.GetByInitiativeAndUserNameAsync(initiativeId, userName, ct);
+
+        if (entity == null)
+        {
+            return new(true)
+            {
+                ResponseBody = errorTranslator.Translate(ValidationErrorCodes.General.ElementNotFound),
+            };
+        }
+
+        entity.FocusArea = entityData.FocusArea;
+
+        await entityRepository.UpdateAsync(entity, ct);
+
+        entityData = mapper.Map(entity);
+
+        logger.AddLog(LogType.Update, "Updated initiative user focus area", "{@EntityData}", entityData);
+
+        return new()
+        {
+            ResponseBody = entityData,
+        };
+    }
+
     /// <summary>
     /// Send notification when a user's level has changed.
     /// </summary>

--- a/src/Application/Services/Statistics/GeneralStatisticsService.cs
+++ b/src/Application/Services/Statistics/GeneralStatisticsService.cs
@@ -67,7 +67,7 @@ public class GeneralStatisticsService : IGeneralStatisticsService
         }
         else
         {
-            totalActiveInitiatives = await initiativeRepository.GetActiveInitiativesCountAsync(ct);
+            totalActiveInitiatives = await initiativeRepository.GetEnabledRecordsCountAsync(ct);
             totalPeopleInvolved = await initiativeRepository.GetPeopleInvolvedInActiveInitiativesCountAsync(ct);
             var totalAreaInSquareKm = await initiativeRepository.GetTotalAreaOfActiveInitiativesAsync(ct);
             totalAreaInHectares = GeometryUtils.ConvertSquareKilometersToHectares(totalAreaInSquareKm);

--- a/src/Application/Services/Users/UserService.cs
+++ b/src/Application/Services/Users/UserService.cs
@@ -10,7 +10,11 @@ using IAVH.BioTablero.CM.Application.Interfaces.ExternalServices;
 using IAVH.BioTablero.CM.Application.Interfaces.General;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Users;
 using IAVH.BioTablero.CM.Core.Domain.Models.Iam;
+using IAVH.BioTablero.CM.Core.Domain.Models.User;
 using IAVH.BioTablero.CM.Core.Domain.Models.Validations;
+using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Initiatives;
+using IAVH.BioTablero.CM.Core.Interfaces.Repositories.Resources;
+using IAVH.BioTablero.CM.Core.Interfaces.Repositories.TerritoryStories;
 
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.OData;
@@ -25,18 +29,47 @@ public class UserService : IUserService
     private readonly IIamService iamService;
 
     private readonly IValidationErrorTranslator errorTranslator;
+    private readonly IInitiativeRepository initiativeRepository;
+    private readonly ITerritoryStoryRepository territoryStoryRepository;
+    private readonly IResourceRepository resourceRepository;
 
     /// <summary>
     /// Constructor.
     /// </summary>
     /// <param name="iamService">IAM service.</param>
     /// <param name="errorTranslator">Error translator.</param>
+    /// <param name="initiativeRepository">Initiative repository.</param>
+    /// <param name="territoryStoryRepository">Territory Story repository.</param>
+    /// <param name="resourceRepository">Resource repository.</param>
     public UserService(
         IIamService iamService,
-        IValidationErrorTranslator errorTranslator)
+        IValidationErrorTranslator errorTranslator,
+        IInitiativeRepository initiativeRepository,
+        ITerritoryStoryRepository territoryStoryRepository,
+        IResourceRepository resourceRepository)
     {
         this.iamService = iamService;
         this.errorTranslator = errorTranslator;
+        this.initiativeRepository = initiativeRepository;
+        this.territoryStoryRepository = territoryStoryRepository;
+        this.resourceRepository = resourceRepository;
+    }
+
+    /// <inheritdoc/>
+    public async Task<CustomWebResponse> GetProfileDataAsync(string userName, CancellationToken ct = default)
+    {
+        var response = new UserProfile
+        {
+            Username = userName,
+            TotalInitiatives = await initiativeRepository.GetEnabledRecordsCountAsync(userName, ct),
+            TotalTerritoryStories = await territoryStoryRepository.GetEnabledRecordsCountAsync(userName, ct),
+            TotalResources = await resourceRepository.GetPublishedRecordsCountAsync(userName, ct),
+        };
+
+        return new()
+        {
+            ResponseBody = response,
+        };
     }
 
     /// <inheritdoc/>

--- a/src/Core/Domain/Models/User/UserProfile.cs
+++ b/src/Core/Domain/Models/User/UserProfile.cs
@@ -1,0 +1,27 @@
+﻿namespace IAVH.BioTablero.CM.Core.Domain.Models.User;
+
+/// <summary>
+/// User profile data.
+/// </summary>
+public class UserProfile
+{
+    /// <summary>
+    /// User name.
+    /// </summary>
+    public string Username { get; set; }
+
+    /// <summary>
+    /// Total initiatives.
+    /// </summary>
+    public int TotalInitiatives { get; set; }
+
+    /// <summary>
+    /// Total territory stories.
+    /// </summary>
+    public int TotalTerritoryStories { get; set; }
+
+    /// <summary>
+    /// Total resources.
+    /// </summary>
+    public int TotalResources { get; set; }
+}

--- a/src/Core/Interfaces/Repositories/Initiatives/IInitiativeRepository.cs
+++ b/src/Core/Interfaces/Repositories/Initiatives/IInitiativeRepository.cs
@@ -82,11 +82,19 @@ public interface IInitiativeRepository : IRepository<Initiative, int>
     Task<Point> GetCentroidAsync(int initiativeId, CancellationToken ct = default);
 
     /// <summary>
-    /// Get count of active initiatives.
+    /// Get the number of enabled records.
     /// </summary>
     /// <param name="ct">Cancellation token.</param>
-    /// <returns>Count of active initiatives.</returns>
-    Task<int> GetActiveInitiativesCountAsync(CancellationToken ct = default);
+    /// <returns>Number of enabled records.</returns>
+    Task<int> GetEnabledRecordsCountAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Get the number of enabled records.
+    /// </summary>
+    /// <param name="userName">User name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Number of enabled records.</returns>
+    Task<int> GetEnabledRecordsCountAsync(string userName, CancellationToken ct = default);
 
     /// <summary>
     /// Get total area of active initiatives with area.

--- a/src/Core/Interfaces/Repositories/Resources/IResourceRepository.cs
+++ b/src/Core/Interfaces/Repositories/Resources/IResourceRepository.cs
@@ -52,4 +52,12 @@ public interface IResourceRepository : IRepository<Resource, int>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if any element exists. False otherwise.</returns>
     Task<bool> AnyByTagAsync(int tagId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get the number of published records.
+    /// </summary>
+    /// <param name="userName">User name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Number of published records.</returns>
+    Task<int> GetPublishedRecordsCountAsync(string userName, CancellationToken ct = default);
 }

--- a/src/Core/Interfaces/Repositories/TerritoryStories/ITerritoryStoryRepository.cs
+++ b/src/Core/Interfaces/Repositories/TerritoryStories/ITerritoryStoryRepository.cs
@@ -63,4 +63,12 @@ public interface ITerritoryStoryRepository : IRepository<TerritoryStory, int>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>Updated territory story data.</returns>
     Task<TerritoryStory> MarkAsFeaturedContentAsync(int id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Get the number of enabled records.
+    /// </summary>
+    /// <param name="userName">User name.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Number of enabled records.</returns>
+    Task<int> GetEnabledRecordsCountAsync(string userName, CancellationToken ct = default);
 }

--- a/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Initiatives/InitiativeRepository.cs
@@ -124,9 +124,16 @@ public class InitiativeRepository : Repository<Initiative, int>, IInitiativeRepo
             .FirstOrDefaultAsync(ct);
 
     /// <inheritdoc/>
-    public async Task<int> GetActiveInitiativesCountAsync(CancellationToken ct = default) =>
+    public async Task<int> GetEnabledRecordsCountAsync(CancellationToken ct = default) =>
         await dbContext.Initiatives
-            .Where(i => i.Enabled)
+            .Where(e => e.Enabled)
+            .CountAsync(ct);
+
+    /// <inheritdoc/>
+    public async Task<int> GetEnabledRecordsCountAsync(string userName, CancellationToken ct = default) =>
+        await dbContext.Initiatives
+            .Include(e => e.InitiativeUsers)
+            .Where(e => e.Enabled && e.InitiativeUsers.Any(e => e.UserName == userName))
             .CountAsync(ct);
 
     /// <inheritdoc/>

--- a/src/Infrastructure/Persistence/Repositories/Resources/ResourceRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Resources/ResourceRepository.cs
@@ -74,6 +74,14 @@ public class ResourceRepository : Repository<Resource, int>, IResourceRepository
         return await GetByIdAsync(entity.Id, ct);
     }
 
+    /// <inheritdoc/>
+    public async Task<int> GetPublishedRecordsCountAsync(string userName, CancellationToken ct = default) =>
+        await dbContext.Resources
+            .Include(e => e.Initiative)
+                .ThenInclude(e => e.InitiativeUsers)
+            .Where(e => !e.IsDraft && e.Initiative.InitiativeUsers.Any(e => e.UserName == userName))
+            .CountAsync(ct);
+
     /// <summary>
     /// Include custom entities.
     /// </summary>

--- a/src/Infrastructure/Persistence/Repositories/Resources/ResourceRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/Resources/ResourceRepository.cs
@@ -77,9 +77,7 @@ public class ResourceRepository : Repository<Resource, int>, IResourceRepository
     /// <inheritdoc/>
     public async Task<int> GetPublishedRecordsCountAsync(string userName, CancellationToken ct = default) =>
         await dbContext.Resources
-            .Include(e => e.Initiative)
-                .ThenInclude(e => e.InitiativeUsers)
-            .Where(e => !e.IsDraft && e.Initiative.InitiativeUsers.Any(e => e.UserName == userName))
+            .Where(e => !e.IsDraft && e.AuthorUserName == userName)
             .CountAsync(ct);
 
     /// <summary>

--- a/src/Infrastructure/Persistence/Repositories/TerritoryStories/TerritoryStoryRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/TerritoryStories/TerritoryStoryRepository.cs
@@ -135,6 +135,14 @@ public class TerritoryStoryRepository : Repository<TerritoryStory, int>, ITerrit
             "Territory Story Image error",
             ct);
 
+    /// <inheritdoc/>
+    public async Task<int> GetEnabledRecordsCountAsync(string userName, CancellationToken ct = default) =>
+        await dbContext.TerritoryStories
+            .Include(e => e.Initiative)
+                .ThenInclude(e => e.InitiativeUsers)
+            .Where(e => e.Enabled && e.Initiative.InitiativeUsers.Any(e => e.UserName == userName))
+            .CountAsync(ct);
+
     /// <summary>
     /// Include custom entities.
     /// </summary>

--- a/src/Infrastructure/Persistence/Repositories/TerritoryStories/TerritoryStoryRepository.cs
+++ b/src/Infrastructure/Persistence/Repositories/TerritoryStories/TerritoryStoryRepository.cs
@@ -138,9 +138,7 @@ public class TerritoryStoryRepository : Repository<TerritoryStory, int>, ITerrit
     /// <inheritdoc/>
     public async Task<int> GetEnabledRecordsCountAsync(string userName, CancellationToken ct = default) =>
         await dbContext.TerritoryStories
-            .Include(e => e.Initiative)
-                .ThenInclude(e => e.InitiativeUsers)
-            .Where(e => e.Enabled && e.Initiative.InitiativeUsers.Any(e => e.UserName == userName))
+            .Where(e => e.Enabled && e.AuthorUserName == userName)
             .CountAsync(ct);
 
     /// <summary>

--- a/src/WebApi/Config/DocsSetup/Examples/Auth/ProfileDataResponseExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/Auth/ProfileDataResponseExample.cs
@@ -1,0 +1,17 @@
+﻿namespace IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Auth;
+
+using IAVH.BioTablero.CM.Core.Domain.Models.User;
+
+using Swashbuckle.AspNetCore.Filters;
+
+/// <summary>
+/// User profile data response example.
+/// </summary>
+public class ProfileDataResponseExample : IExamplesProvider<UserProfile>
+{
+    /// <inheritdoc/>
+    public UserProfile GetExamples() => new()
+    {
+        Username = "initiative-user@example.com",
+    };
+}

--- a/src/WebApi/Config/DocsSetup/Examples/InitiativeUser/InitiativeUserEditFocusAreaRequestExample.cs
+++ b/src/WebApi/Config/DocsSetup/Examples/InitiativeUser/InitiativeUserEditFocusAreaRequestExample.cs
@@ -1,0 +1,17 @@
+﻿namespace IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.InitiativeUser;
+
+using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
+
+using Swashbuckle.AspNetCore.Filters;
+
+/// <summary>
+/// Initiative User edit focus area request example.
+/// </summary>
+public class InitiativeUserEditFocusAreaRequestExample : IExamplesProvider<InitiativeUserDto>
+{
+    /// <inheritdoc/>
+    public InitiativeUserDto GetExamples() => new()
+    {
+        FocusArea = "Focus area example",
+    };
+}

--- a/src/WebApi/Controllers/Rest/Auth/AuthController.cs
+++ b/src/WebApi/Controllers/Rest/Auth/AuthController.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
+using IAVH.BioTablero.CM.Application.Interfaces.Services.Users;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Auth;
 using IAVH.BioTablero.CM.WebApi.Interfaces;
@@ -20,13 +21,29 @@ using Swashbuckle.AspNetCore.Filters;
 /// </summary>
 /// <param name="webTools">General web tools.</param>
 /// <param name="initiativeService">Inititive service.</param>
+/// <param name="userService">User service.</param>
 [ApiController]
 [Route("[controller]")]
 [Produces("application/json")]
 [ApiConventionType(typeof(CustomApiConventions))]
 public class AuthController(IWebTools webTools,
-    IInitiativeService initiativeService) : ControllerBase
+    IInitiativeService initiativeService,
+    IUserService userService) : ControllerBase
 {
+    /// <summary>
+    /// Get profile data from authenticated user.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>User profile data.</returns>
+    [Authorize]
+    [HttpGet("MyProfile")]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(ProfileDataResponseExample))]
+    public async Task<IActionResult> MyProfile(CancellationToken ct)
+    {
+        var response = await userService.GetProfileDataAsync(HttpContext.GetUserName(), ct);
+        return webTools.CustomResponse(response);
+    }
+
     /// <summary>
     /// Get initiatives data from authenticated user.
     /// </summary>

--- a/src/WebApi/Controllers/Rest/Auth/AuthController.cs
+++ b/src/WebApi/Controllers/Rest/Auth/AuthController.cs
@@ -3,10 +3,12 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+using IAVH.BioTablero.CM.Application.DTOs.Initiatives;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Initiatives;
 using IAVH.BioTablero.CM.Application.Interfaces.Services.Users;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples;
 using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.Auth;
+using IAVH.BioTablero.CM.WebApi.Config.DocsSetup.Examples.InitiativeUser;
 using IAVH.BioTablero.CM.WebApi.Interfaces;
 using IAVH.BioTablero.CM.WebApi.Utils;
 
@@ -20,7 +22,8 @@ using Swashbuckle.AspNetCore.Filters;
 /// Authentication data controller.
 /// </summary>
 /// <param name="webTools">General web tools.</param>
-/// <param name="initiativeService">Inititive service.</param>
+/// <param name="initiativeService">Initiative service.</param>
+/// <param name="initiativeUserService">Initiative User service.</param>
 /// <param name="userService">User service.</param>
 [ApiController]
 [Route("[controller]")]
@@ -28,6 +31,7 @@ using Swashbuckle.AspNetCore.Filters;
 [ApiConventionType(typeof(CustomApiConventions))]
 public class AuthController(IWebTools webTools,
     IInitiativeService initiativeService,
+    IInitiativeUserService initiativeUserService,
     IUserService userService) : ControllerBase
 {
     /// <summary>
@@ -56,6 +60,24 @@ public class AuthController(IWebTools webTools,
     public async Task<IActionResult> GetListInitiativesData(CancellationToken ct)
     {
         var response = await initiativeService.GetByUserNameAsync(HttpContext.GetUserName(), ct);
+        return webTools.CustomResponse(response);
+    }
+
+    /// <summary>
+    /// Edit my focus area.
+    /// </summary>
+    /// <param name="initiativeId">Initiative identifier.</param>
+    /// <param name="requestData">Entity data.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Updated entity data.</returns>
+    [HttpPut("MyFocusArea/{initiativeId}")]
+    [Consumes("application/json")]
+    [Authorize]
+    [SwaggerRequestExample(typeof(InitiativeUserDto), typeof(InitiativeUserEditFocusAreaRequestExample))]
+    [SwaggerResponseExample(StatusCodes.Status200OK, typeof(InitiativeUserResponseExample))]
+    public async Task<IActionResult> EditMyFocusArea(int initiativeId, [FromBody] InitiativeUserDto requestData, CancellationToken ct)
+    {
+        var response = await initiativeUserService.UpdateFocusAreaAsync(initiativeId, HttpContext.GetUserName(), requestData, ct);
         return webTools.CustomResponse(response);
     }
 }

--- a/src/WebApi/Controllers/Rest/Auth/AuthController.cs
+++ b/src/WebApi/Controllers/Rest/Auth/AuthController.cs
@@ -37,6 +37,7 @@ public class AuthController(IWebTools webTools,
     /// <returns>User profile data.</returns>
     [Authorize]
     [HttpGet("MyProfile")]
+    [ProducesResponseType(typeof(ProfileDataResponseExample), StatusCodes.Status200OK)]
     [SwaggerResponseExample(StatusCodes.Status200OK, typeof(ProfileDataResponseExample))]
     public async Task<IActionResult> MyProfile(CancellationToken ct)
     {


### PR DESCRIPTION
## 🛠️ Cambios
- Se ha agregado el endpoint `/Auth/MyProfile` para obtener datos básicos de mi perfil
- Se ha agregado el endpoint `/Auth/MyFocusArea/{initiativeId}` para permitir a los usuarios editar su área de interés para una iniciativa. Anteriormente se hacía con el controlador `Initiativeuser`, pero solo estaba habilitado para líderes y administradores
- Se hicieron algunas refactorizaciones y cambios menores

## 📝 Tareas asociadas
Resuelve [lib-691](https://linear.app/biodev/issue/LIB-691)

## 🤔 Consideraciones
- No fusionar la rama de este PR hasta que #49 esté aprobado y cerrado
- Teniendo en cuenta los criterios de aceptación de la historia de usuario, se pueden obtener las iniciativas de un usuario autenticado y los roles de cada una de ellas con el endpoint `/Auth/InitiativesData`. Este existe desde hace rato

## ✅ Verificaciones
- No aplica.