### PR TITLE
Cambios en la base de datos

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 services:
 
   db:
-    image: timescale/timescaledb-ha:pg17.5-ts2.21.1-oss
+    image: postgis/postgis:17-3.6-alpine
     container_name: bt-cm-db
     restart: "no"
     environment:
@@ -19,8 +19,14 @@ services:
     volumes:
       - db_data:/home/postgres/pgdata
       # Keycloak database setup
-      - ./docker/keycloak/db/init-db.sql:/docker-entrypoint-initdb.d/init-keycloak-db.sql:ro
-      - ./docker/keycloak/db/init-schema.sql:/docker-entrypoint-initdb.d/init-keycloak-schema.sql:ro
+      - ./docker/keycloak/db:/tmp/init:ro
+    entrypoint:
+      - sh
+      - -c
+      - |
+        cp /tmp/init/*.sql /docker-entrypoint-initdb.d/ && \
+        chmod 644 /docker-entrypoint-initdb.d/*.sql && \
+        exec docker-entrypoint.sh postgres
     networks:
       - bt-search-network
 

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     healthcheck:
-      test: ["CMD", "pg_isready"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -17,7 +17,7 @@ services:
     ports:
       - "${DB_PORT:-5432}:5432"
     volumes:
-      - db_data:/home/postgres/pgdata
+      - db_data:/var/lib/postgresql/data
       # Keycloak database setup
       - ./docker/keycloak/db:/tmp/init:ro
     entrypoint:

--- a/src/Infrastructure/Persistence/Migrations/20250721213943_InitialMigration.cs
+++ b/src/Infrastructure/Persistence/Migrations/20250721213943_InitialMigration.cs
@@ -30,13 +30,11 @@ public partial class InitialMigration : Migration
                 client_ip = table.Column<string>(type: "text", nullable: true),
                 client_agent = table.Column<string>(type: "text", nullable: true),
                 properties = table.Column<string>(type: "jsonb", nullable: false),
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_logs", x => x.id);
             });
-
-        // Create index on identifier
-        migrationBuilder.Sql("CREATE INDEX ON logs.logs (id);");
-
-        // Convert table to hypertable (TimescaleDB)
-        migrationBuilder.Sql("SELECT create_hypertable('logs.logs', 'timestamp');");
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
## 🛠️ Cambios
- Se han modificado las migraciones para no utilizar `TimescaleDB`
- Se ha modificado el docker compose del ambiente de desarrollo para usar `PostGIS` en lugar de `TimescaleDB`.

## 📝 Tareas asociadas
Resuelve [lib-735](https://linear.app/biodev/issue/LIB-735)

## 🤔 Consideraciones
- No fusionar hasta que #52 esté aprobado y cerrado.
- Es necesario recrear la base de datos para aplicar los cambios

## ✅ Verificaciones
- No aplica.