### PR TITLE
Restricciones adicionales de iniciativas

### DIFF
--- a/src/Core/Domain/Entities/Indicators/IndicatorValue.cs
+++ b/src/Core/Domain/Entities/Indicators/IndicatorValue.cs
@@ -22,12 +22,12 @@ public class IndicatorValue : BaseEntity<int>, IAggregateRoot
     /// <summary>
     /// Date.
     /// </summary>
-    public DateTimeOffset Date { get; set; }
+    public DateTime Date { get; set; }
 
     /// <summary>
     /// Date end.
     /// </summary>
-    public DateTimeOffset? DateEnd { get; set; }
+    public DateTime? DateEnd { get; set; }
 
     /// <summary>
     /// Indicator Value.

--- a/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorValueConfig.cs
+++ b/src/Infrastructure/Persistence/Config/Entities/Indicators/IndicatorValueConfig.cs
@@ -31,9 +31,11 @@ public class IndicatorValueConfig : IEntityTypeConfiguration<IndicatorValue>
 
         builder.Property(i => i.Date)
             .HasColumnName("date")
+            .HasColumnType("timestamp without time zone")
             .IsRequired();
 
         builder.Property(i => i.DateEnd)
+            .HasColumnType("timestamp without time zone")
             .HasColumnName("date_end");
 
         builder.Property(i => i.Value)
@@ -53,5 +55,23 @@ public class IndicatorValueConfig : IEntityTypeConfiguration<IndicatorValue>
         builder.HasOne(e => e.MeasureUnit)
             .WithMany(p => p.IndicatorValues)
             .HasForeignKey(e => e.MeasureUnitId);
+
+        builder
+            .ToTable(t =>
+            t.HasCheckConstraint(
+                "chk_date_end_after_date",
+                "\"date_end\" IS NULL OR \"date_end\" > \"date\""));
+
+        builder
+            .ToTable(t =>
+            t.HasCheckConstraint(
+                "chk_value_greater_than_lower_limit",
+                "\"lower_limit\" IS NULL OR \"value\" > \"lower_limit\""));
+
+        builder
+            .ToTable(t =>
+            t.HasCheckConstraint(
+                "chk_upper_limit_greater_than_value",
+                "\"upper_limit\" IS NULL OR \"upper_limit\" > \"value\""));
     }
 }

--- a/src/Infrastructure/Persistence/Migrations/20260618194423_AddIndicatorValueConstraints.Designer.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260618194423_AddIndicatorValueConstraints.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using IAVH.BioTablero.CM.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(GeneralContext))]
-    partial class GeneralContextModelSnapshot : ModelSnapshot
+    [Migration("20260618194423_AddIndicatorValueConstraints")]
+    partial class AddIndicatorValueConstraints
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Persistence/Migrations/20260618194423_AddIndicatorValueConstraints.cs
+++ b/src/Infrastructure/Persistence/Migrations/20260618194423_AddIndicatorValueConstraints.cs
@@ -1,0 +1,90 @@
+﻿#nullable disable
+
+namespace IAVH.BioTablero.CM.Infrastructure.Persistence.Migrations;
+
+using System;
+
+using Microsoft.EntityFrameworkCore.Migrations;
+
+/// <inheritdoc />
+public partial class AddIndicatorValueConstraints : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<DateTime>(
+            name: "date_end",
+            schema: "indicators",
+            table: "indicator_value",
+            type: "timestamp without time zone",
+            nullable: true,
+            oldClrType: typeof(DateTimeOffset),
+            oldType: "timestamp with time zone",
+            oldNullable: true);
+
+        migrationBuilder.AlterColumn<DateTime>(
+            name: "date",
+            schema: "indicators",
+            table: "indicator_value",
+            type: "timestamp without time zone",
+            nullable: false,
+            oldClrType: typeof(DateTimeOffset),
+            oldType: "timestamp with time zone");
+
+        migrationBuilder.AddCheckConstraint(
+            name: "chk_date_end_after_date",
+            schema: "indicators",
+            table: "indicator_value",
+            sql: "\"date_end\" IS NULL OR \"date_end\" > \"date\"");
+
+        migrationBuilder.AddCheckConstraint(
+            name: "chk_upper_limit_greater_than_value",
+            schema: "indicators",
+            table: "indicator_value",
+            sql: "\"upper_limit\" IS NULL OR \"upper_limit\" > \"value\"");
+
+        migrationBuilder.AddCheckConstraint(
+            name: "chk_value_greater_than_lower_limit",
+            schema: "indicators",
+            table: "indicator_value",
+            sql: "\"lower_limit\" IS NULL OR \"value\" > \"lower_limit\"");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropCheckConstraint(
+            name: "chk_date_end_after_date",
+            schema: "indicators",
+            table: "indicator_value");
+
+        migrationBuilder.DropCheckConstraint(
+            name: "chk_upper_limit_greater_than_value",
+            schema: "indicators",
+            table: "indicator_value");
+
+        migrationBuilder.DropCheckConstraint(
+            name: "chk_value_greater_than_lower_limit",
+            schema: "indicators",
+            table: "indicator_value");
+
+        migrationBuilder.AlterColumn<DateTimeOffset>(
+            name: "date_end",
+            schema: "indicators",
+            table: "indicator_value",
+            type: "timestamp with time zone",
+            nullable: true,
+            oldClrType: typeof(DateTime),
+            oldType: "timestamp without time zone",
+            oldNullable: true);
+
+        migrationBuilder.AlterColumn<DateTimeOffset>(
+            name: "date",
+            schema: "indicators",
+            table: "indicator_value",
+            type: "timestamp with time zone",
+            nullable: false,
+            oldClrType: typeof(DateTime),
+            oldType: "timestamp without time zone");
+    }
+}


### PR DESCRIPTION
## 🛠️ Cambios
- Se han agregado restricciones para los indicadores a nivel de la base de datos (tabla `indicator_value`) para evitar errores al insertar datos nuevos
  - Ahora se valida que la fecha final de un intervalo sea mayor que la fecha inicial
  - Se valida que el intervalo de confianza de un valor tenga valores correctos
- Se eliminó la zona horaria de la fecha de los valores de los indicadores. Estos valores deben ser estáticos y con la zona horaria estaban generando inconsistencias

## 📝 Tareas asociadas
Resuelve parcialmente [lib-761](https://linear.app/biodev/issue/LIB-761)

## 🤔 Consideraciones
- Es necesario ejecutar las migraciones para aplicar los cambios

## ✅ Verificaciones
- No aplica